### PR TITLE
♻️ci: add API_URL to playwright test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: 🧪 Run Playwright tests
         run: bun playwright test
+        env:
+          API_URL: ${{ secrets.API_URL }}
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the Playwright test workflow to use a secret API_URL environment variable during test execution