### PR TITLE
♻️ci: use constant to API_URL

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
       - name: 🧪 Run Playwright tests
         run: bun playwright test
         env:
-          API_URL: ${{ secrets.API_URL }}
+          API_URL: https://dcrs.vercel.app
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update GitHub Actions workflow to use a static API URL instead of a secret-based configuration