### PR TITLE
🚑fix: remove API_URL from playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: 🧪 Run Playwright tests
         run: bun playwright test
-        env:
-          API_URL: https://dcrs.vercel.app
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v4

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,10 +1,29 @@
-import { expect, test } from "@playwright/test"
+import { type Page, expect, test } from "@playwright/test"
 
 const title: RegExp = /DCRS/
 
 test("has title", async ({ page }) => {
-  await page.goto("/")
+  // await page.goto("/")
+  await gotoWithRetry(page, "/")
 
   // Expect a title "to contain" a substring.
   await expect(page).toHaveTitle(title)
 })
+
+async function gotoWithRetry(page: Page, url: string, options = {}) {
+  const maxRetries = 3
+  const defaultOptions = { timeout: 20000, waitUntil: "load" as const }
+  const mergedOptions = { ...defaultOptions, ...options }
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await page.goto(url, mergedOptions)
+      return
+    } catch (error) {
+      if (attempt === maxRetries) {
+        throw error
+      }
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+    }
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

Improve e2e test reliability by adding a retry mechanism for page navigation and removing hardcoded API_URL from GitHub Actions workflow

Bug Fixes:
- Add a retry mechanism to handle potential transient page load failures in Playwright tests

Chores:
- Remove hardcoded API_URL environment variable from GitHub Actions workflow