### PR TITLE
🚑fix: postgres port on GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -135,7 +135,7 @@ jobs:
           provenance: ${{ fromJSON(env.IS_PUSH) && 'mode=max' }}
           push: ${{ fromJSON(env.IS_PUSH) }}
           sbom: ${{ fromJSON(env.IS_PUSH) }}
-          secrets: database=postgres://postgres:postgres@localhost:5433/postgres
+          secrets: database=postgres://postgres:postgres@localhost:5432/postgres
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: 🪪 Attest

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -89,7 +89,7 @@ jobs:
         platforms: linux/arm64
         provenance: false
         push: true
-        secrets: database=postgres://postgres:postgres@localhost:5433/postgres
+        secrets: database=postgres://postgres:postgres@localhost:5432/postgres
         tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
     - name: 🥩 Update Lambda Function

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,7 +52,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5433/postgres
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
 
     steps:
       - name: 📥 Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: 🧪 Test app
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5433/postgres
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: |
           bun test:app &> >(tee -p test.log) || echo STATUS=$? >> $GITHUB_ENV
           {


### PR DESCRIPTION
## Summary by Sourcery

Fix PostgreSQL connection port in GitHub Actions workflows

Bug Fixes:
- Corrected the PostgreSQL connection port from 5433 to 5432 across multiple GitHub Actions workflow files

CI:
- Updated database connection strings in Docker, Lambda, Playwright, and test workflow configurations to use the standard PostgreSQL port