### PR TITLE
🆙bump: version up dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
         "@types/bun": "^1.2.14",
         "@types/react": "^19.1.5",
         "@types/react-dom": "^19.1.5",
-        "daisyui": "^5.0.37",
+        "daisyui": "^5.0.38",
         "drizzle-kit": "^0.30.6",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.7",
@@ -259,23 +259,23 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.0", "", { "dependencies": { "@types/node": "^22.10.2", "@types/pg": "^8.8.0" } }, "sha512-XWmEeWpBXIoksZSDN74kftfTnXFEGZ3iX8jbANWBc+ag6dsiQuvuR4LgB0WdCOKMb5AQgjqgufc0TgAsZubUYw=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.52", "", {}, "sha512-WLCC+OfAAhl7yD4k+s0Lp2Kmrx7BUTfzBvpootbwXGl3tiOKQEOFEAx2xQH71MvuS+QRzctV2guQ7n/OlR41Kg=="],
+    "@next/env": ["@next/env@15.4.0-canary.53", "", {}, "sha512-ErvXhMfbV6wcHZapQb4iiCVkPiyKSt2E1sN0ciH9SYWRwzRRTtLqyg+3z1neIVEaSKrfvrqSmYk2KPVtjBjXAQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.52", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AirTVuz0DdSagf+dMXFrFij+4CxgjzjPitIWn85SQQReb3vLQ49Z77OiE9v4mq4cZWmkGNf+L66PCh9b+u0gAQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.53", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YnmYsHz8kwIv2ccPMOBHlzBTEerdD6waAcX1tmYh2Qp4ytXsI/Y9dH7RUKz3Z43D4izME0KNnpLs3Xa/G5A5lA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.52", "", { "os": "darwin", "cpu": "x64" }, "sha512-dODJDDZDvN7yDg5v4IGUsXRTiDnO669LjH8c1ClivzIdB3AmUJ+8a6G4xv5fJp2AHDmyj7g6LCYCNc/cEAiiSw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.53", "", { "os": "darwin", "cpu": "x64" }, "sha512-xjp08ShwvTTEsDzG4G2/mcN013w7Ypr4Nfa+VWDVzCkEencAj0hV6rdzL6gLHZqHCv3UFWpE7NK6hmUYradFRA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-DdEjMMbce2xkssx30nh0LHY/U3yQTPOm96eg3AbyBv+InExnbjUYtx4RAw1NKLsfuyIynT9FgNPehBuEjLxtTg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.53", "", { "os": "linux", "cpu": "arm64" }, "sha512-j+/IG+/vXQhkSG02BUfdgO14cCjkY9xKK77MUlXUl47BQx6mQSS3bNO6gBQPcsaYGPslmWyD4wKjogKAHhNaSg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-4kTj/W3/c10pDEsy91lvnsJ/VDAn5hESPcTeLQvFmUVu6p54DcJ4MhpuRRhUl/+3osY5dwkc9zG3/R9BkOSwRA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.53", "", { "os": "linux", "cpu": "arm64" }, "sha512-xvizFNF52DCuUox5gnydR8Fn7X1g226vCjWuX5pg8aZiaXgYvNO/nJgCmiKUoZuTqJv95ku1EFw8/ICOEiWQFA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-7g3P6NqDDh52ydRmUlTAV4FrSPsXUousbKf5RDM0D/118hlFn7DRordjYs0LyB5PP+uVRGLjEQFHQ/wi/dNY6A=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.53", "", { "os": "linux", "cpu": "x64" }, "sha512-dLHqXW31wtD9ofM3lUif+qvzs0n8LZdEWr7pHzDax9iYf09IrnOoA4VPh3S1KUEPB/J4GORgzgwQlSxNcR1Qyg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-5qCSO0xAmPVRIql+HLY9Utl/vkUSzgrH14t8yOl0gZtB0B4DABSUUJ8yuzr3ET/YrrEckGUcYutgFoo5Ao2VWw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.53", "", { "os": "linux", "cpu": "x64" }, "sha512-pItF76pBfQEsz5iy/a8X4sW5vMHSS/A/BqxlkULuUNvJFdgo9XhTPvllWxIsJJWlRcnGehqpHqJ1Ze4Jug6h5A=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.52", "", { "os": "win32", "cpu": "arm64" }, "sha512-GRgmB/03fsQbSQguxrNGYOeY+n4IoEbKyCDh/ftPIh9KiCE6BzanVSIxgJom7ir3c0Lyz8LNTNJSIq2XDMXp3w=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.53", "", { "os": "win32", "cpu": "arm64" }, "sha512-T+Xf+DvfgGpR5ywAy0dS3y3ZZneOlcD8sshYfOoWmBs23juKTP6pEXbCTbxtDJInXHkDcPOwlV322CUf9hSeHQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.52", "", { "os": "win32", "cpu": "x64" }, "sha512-vrX3kaJWQBbDApALLB7nQZongAg+uhkw0OBq9AK+GT/1dcW1XvarJYktGvOmNMLfkOIDbRrz68wjTt98/BU1CA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.53", "", { "os": "win32", "cpu": "x64" }, "sha512-cTcpBIahEfSte72JhI2FdixDdF+9UZjKcqNAjMh+UNBg5s9mSxWlQbM3YrxxsBiqDAhLpnsXm0jMGQ+2S3y3VQ=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
@@ -461,7 +461,7 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
-    "daisyui": ["daisyui@5.0.37", "", {}, "sha512-PLc+MhWAqTwolygEGPDi+ac+OsFqIt9nZylTIiyVlEx8loYL7Pt7hNWb8cp5pQQ9dhjYnda1ERiuM6OsJmvPGw=="],
+    "daisyui": ["daisyui@5.0.38", "", {}, "sha512-RsLsdePT/4ZU0N+vWivR/zJyAL9U9EeRtbis3K3VDvewrqY0NOFYBh6ib3n9GfN3Wb+FHwP80ae1qOA6ONWvyw=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -543,7 +543,7 @@
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "next": ["next@15.4.0-canary.52", "", { "dependencies": { "@next/env": "15.4.0-canary.52", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.52", "@next/swc-darwin-x64": "15.4.0-canary.52", "@next/swc-linux-arm64-gnu": "15.4.0-canary.52", "@next/swc-linux-arm64-musl": "15.4.0-canary.52", "@next/swc-linux-x64-gnu": "15.4.0-canary.52", "@next/swc-linux-x64-musl": "15.4.0-canary.52", "@next/swc-win32-arm64-msvc": "15.4.0-canary.52", "@next/swc-win32-x64-msvc": "15.4.0-canary.52", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-A8Jv61u5x29ySMakrF+qDCp/Sy4J7H6OPa7gxcz3tCB9Y98a6ebAUShWVIvZYJJ7WGLXeQ74qMbmdKff2be3MQ=="],
+    "next": ["next@15.4.0-canary.53", "", { "dependencies": { "@next/env": "15.4.0-canary.53", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.53", "@next/swc-darwin-x64": "15.4.0-canary.53", "@next/swc-linux-arm64-gnu": "15.4.0-canary.53", "@next/swc-linux-arm64-musl": "15.4.0-canary.53", "@next/swc-linux-x64-gnu": "15.4.0-canary.53", "@next/swc-linux-x64-musl": "15.4.0-canary.53", "@next/swc-win32-arm64-msvc": "15.4.0-canary.53", "@next/swc-win32-x64-msvc": "15.4.0-canary.53", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-k5xsGnXKkecgKYNM1ixizb21OgKG3Gn4dl3wOMnOx0jPsaVZiYYA7GlXPHfRbCDJcVeiZX4dqm3Y51k074tHQQ=="],
 
     "next-auth": ["next-auth@5.0.0-beta.28", "", { "dependencies": { "@auth/core": "0.39.1" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0-0", "nodemailer": "^6.6.5", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-2RDR1h3DJb4nizcd5UBBwC2gtyP7j/jTvVLvEtDaFSKUWNfou3Gek2uTNHSga/Q4I/GF+OJobA4mFbRaWJgIDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/bun": "^1.2.14",
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
-    "daisyui": "^5.0.37",
+    "daisyui": "^5.0.38",
     "drizzle-kit": "^0.30.6",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.7",


### PR DESCRIPTION
## Sourcery によるサマリー

daisyUI の依存関係を最新のパッチバージョンに引き上げ、lockfile を更新します。

雑務:
- daisyUI を ^5.0.37 から ^5.0.38 に引き上げ
- bun.lock ファイルを再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump daisyUI dependency to the latest patch version and update the lockfile.

Chores:
- Bump daisyUI from ^5.0.37 to ^5.0.38
- Regenerate bun.lock file

</details>