### PR TITLE
♻️chore: change dependabot node ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       ci:
         patterns:
           - "*"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- `package-ecosystem` を Dependabot の設定で npm から bun に切り替え

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Switch package-ecosystem from npm to bun in Dependabot config

</details>