### PR TITLE
test: remove unnecessary bunfig.toml file

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-05" }, "bin": { "playwright": "cli.js" } }, "sha512-d3R1qrHgKIpuvZeVDbSc6YfUWv5GXgAevKDX/xHZCqVJwY+BPNqjnnl3MmbgAUj5pO90bS6B2HlziyvZyo3emA=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-06" }, "bin": { "playwright": "cli.js" } }, "sha512-d8EVgj2aFLWq7anFJbFg/2TbvaygUrK2SjaN+EhqvRi+KBIOO8z+W6AahJh6gWNUgtHNCCpWTOaCjgScdooi0Q=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -558,9 +558,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-05" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-CKODBN4QyCOPZVr4DQT77P8gmJ8bD3EZTO6f0T2nJ8YJYcjhfSd9xUjybmCmIw1q5gfCiwCAgp6Ed0iLhXZYoA=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-06" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-LoxuPYLnhxcizhOvE8ycVOOfjKsNkBAFyb3XsAbDjKBCPjHkEJ+LvxgSTqZnkJMubZ4E0eioKpFN8jrX8Gjt5Q=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-05", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-IsuKgjfwsRqC5x3pQ/X+IJBj8zFOzKbxDmWjO8OIQKMzPDyoFCCYrI4lqOAYZ4ffmZeBdNXEu93ZrS+NYhduWA=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-06", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-L57Jn2+3Q90cU3OtRqJbHxryrMnANJJ075UltpXMEmvur/zbXNe5R2t798gcco3eWmjrBqL7Bc9MK0xKjG6tXQ=="],
 
     "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[test]
-preload = "./happydom.tsx"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check --write",
-    "test:app": "bun test test/app",
+    "test:app": "bun test test/app --preload ./happydom.tsx",
     "test:e2e": "playwright test",
     "test:report": "playwright show-report",
     "generate": "drizzle-kit generate",


### PR DESCRIPTION
## Sourceryによるサマリー

不要なBun設定ファイルを削除し、Bunテストコマンドを調整してDOM shimをプリロードします。

機能拡張:
- `test:app`スクリプトを更新し、HappyDOM shimのプリロードを含めるようにしました。

雑務:
- `bunfig.toml`設定ファイルを削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unnecessary Bun configuration file and adjust the Bun test command to preload a DOM shim

Enhancements:
- Update the test:app script to include a preload for the HappyDOM shim

Chores:
- Remove the bunfig.toml configuration file

</details>