### PR TITLE
chore: 🗑️ remove kazutan1230 from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Marukome0743 @kazutan1230
+* @Marukome0743


### PR DESCRIPTION
## Sourcery によるサマリー

雑務:
- CODEOWNERS から kazutan1230 のエントリを削除

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

雑務：
- `CODEOWNERS`ファイルからkazutan1230のエントリーを削除しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove the kazutan1230 entry from the CODEOWNERS file

</details>

</details>