### PR TITLE
build: 🆙 version up dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.16.0-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.17.0-rc1-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@tailwindcss/postcss": "^4.1.10",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.3.0",
-        "@types/bun": "^1.2.15",
+        "@types/bun": "^1.2.16",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "daisyui": "^5.0.43",
@@ -284,7 +284,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-11", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-11" }, "bin": { "playwright": "cli.js" } }, "sha512-QKcosS2Xnys48RonqVmJ40fzNO7X4Uco5zb2CBPuXurQ91n3cLq1e7V5QARyJZWbhjtH/YcaMzb/y+jWNt7cTA=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-12", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-12" }, "bin": { "playwright": "cli.js" } }, "sha512-Aee4NEo845rF9+4WX58mnMgrP01qfhwLRth1wjVzbqHPJy0YmOSvgh/vv1LXc9cPNZTziPabZrEi5b5JoCDMGQ=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -424,7 +424,7 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.2.15", "", { "dependencies": { "bun-types": "1.2.15" } }, "sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA=="],
+    "@types/bun": ["@types/bun@1.2.16", "", { "dependencies": { "bun-types": "1.2.16" } }, "sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ=="],
 
     "@types/node": ["@types/node@20.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q=="],
 
@@ -446,7 +446,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.2.15", "", { "dependencies": { "@types/node": "*" } }, "sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w=="],
+    "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001712", "", {}, "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig=="],
 
@@ -560,9 +560,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-11", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-11" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Y8Ar65v7r1zkVii99XrCbm50cHsy4q4fL9X8/YD16agXfPJMI1Esx3jJwWHNGDadIL5mn8Io5J7DOLy0DrDrBA=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-12", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-12" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-O/IyiFmkRcIjxXquKPbwJmXK+jkCUFYDob9D29zbsdR1mWZ9fS6ZRN3NumBfw6JkJDlcADTu2DEziuY6rVHhkw=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-11", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-oW1s0TQlv0m/csBtArn8Ee3V5zuAjkVu3SJDIS6So8TyIynpTYBcMdovIGM+yE+6jJF3HwByQ8XoBSsVVL+fFw=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-12", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-B11EEdc+U0vZ1Hpzeuy5Mo+LgMiMzy5lWY1QJGcSYw2HPTb9hhGUEpiY43gFw6tXhxtOwbAiz5AmxG+ZlFNJBA=="],
 
     "postcss": ["postcss@8.5.5", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg=="],
 
@@ -672,7 +672,7 @@
 
     "@types/pg/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
-    "bun-types/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
+    "bun-types/@types/node": ["@types/node@22.15.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@tailwindcss/postcss": "^4.1.10",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
-    "@types/bun": "^1.2.15",
+    "@types/bun": "^1.2.16",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "daisyui": "^5.0.43",


### PR DESCRIPTION
## Sourceryによるサマリー

開発用依存関係を最新バージョンに更新

機能拡張:
- @types/bun を ^1.2.15 から ^1.2.16 にアップグレード

ビルド:
- Dockerfile の構文ディレクティブを dockerfile-upstream v1.16.0-labs から v1.17.0-rc1-labs に更新

<details>
<summary>Original summary in English</summary>

## Sourcery によるサマリー

開発依存関係の更新とビルド構成のアップデート

ビルド：
- Dockerfile の構文ディレクティブを dockerfile-upstream v1.17.0-rc1-labs に更新

雑務：
- @types/bun の開発依存関係を ^1.2.16 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump development dependencies and update build configuration

Build:
- Update Dockerfile syntax directive to dockerfile-upstream v1.17.0-rc1-labs

Chores:
- Bump @types/bun development dependency to ^1.2.16

</details>

</details>