### PR TITLE
build: 🐳 version up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.17.0-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.17.1-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-19", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-19" }, "bin": { "playwright": "cli.js" } }, "sha512-lPVdSQHtCg1vVYC6ndhQo0sOhC4iRA5lgMyFJD3otmpqsxRzq1GVkfsvLmjxblw1RQSxqjlMK7hvKuKpi3C+TQ=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-20", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-20" }, "bin": { "playwright": "cli.js" } }, "sha512-aPD+M2wCSEOdKez1EGi252PRqa31BKmt522rKKe5d3BhCyRqL6AHjoJdtSVV+m3bW4YXbS8kAk3R5XF6k0AKag=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -562,9 +562,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-19", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-19" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0K/bcZQ/At/EWq1eNL4lRZvvmqe6Tg+8PjcaqpUbLlzWMWG3a26/Vko0DVoHBZ5sTLSXygT41/DOzpLS0MyBmg=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-20", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-20" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-O02PNM/nIHMmfqKi7ICktzcpaO7eGqIz0kqI8Gja0ZhqA5EYumU4riwHP1CkOSukWjyNMF7F26gSPXpErlwYBA=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-19", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-N8obQMc6hoBMN6C8mcVHzTASk3QKoqtaeECTLkbOhvSTV6AgTAMZa0bwiM6QGAc/V1HZQzx2QQkCVFsFETNogw=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-20", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-RNsOShxnlTT1lTvxLbWCIxhbJ18kbC4twFpRTlNlher8o3ZVBCzMMwmPU+o+1n0J0+zhlCsDAm6f+PBRrEqDoA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

Dockerfileの構文バージョンを上げ、それに応じてBunの依存関係ロックファイルを更新します。

ビルド：
- Dockerfileの上流構文バージョンを1.17.0-labsから1.17.1-labsに上げます

雑務：
- Bunのカナリアバージョン変更を取り込むために、bun.lockを再生成します

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump the Dockerfile syntax version and update the Bun dependency lockfile accordingly.

Build:
- Bump Dockerfile upstream syntax version from 1.17.0-labs to 1.17.1-labs

Chores:
- Regenerate bun.lock to incorporate Bun canary version changes

</details>