### PR TITLE
chore: ♻️ disable commitlint action on sapling branch

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,7 @@ jobs:
   commitlint:
     name: Commitlint
     runs-on: ubuntu-latest
+    if: startsWith(github.ref_name, 'sapling-pr-archive-') == false
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- `commitlint.yml` 内で、ブランチ名が "sapling-pr-archive-" で始まる場合、Commitlint ジョブをスキップする条件を追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add conditional to skip the Commitlint job when the branch name starts with "sapling-pr-archive-" in commitlint.yml

</details>