### PR TITLE
chore: add noUnusedImports rule to Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,9 @@
   },
   "linter": {
     "rules": {
+      "correctness": {
+        "noUnusedImports": "error"
+      },
       "nursery": {
         "useSortedClasses": "error"
       },

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-24", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-24" }, "bin": { "playwright": "cli.js" } }, "sha512-kiwx3zYMG4lYFpPR7tTt2rg7Gsll5s3Xl979ZdK1wORamgMa9Inty/GfMnxCkgSu5EkO8rut/A6CWh2NOiJLxw=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-25", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-25" }, "bin": { "playwright": "cli.js" } }, "sha512-H2r8OiDis2iLlbkRNwDsuube6H8gr+BLNc90szA8ARMsPRTlmsVgxvs6gOE+A4aDvHNPpZUF3igUKleRg+zrAQ=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -562,9 +562,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-24", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-24" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-9ZhwSRGGQ8/7DxuYhfIjdL6Cp5QY3nR7FkcxbWmQTgKi09bxkVVYAkjZdeZI4tHExrWRZKxFgMqZTyf6YXSMZQ=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-25", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-25" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wYnvf++6p+41IuZdu8yK8ELfltrOrGQQIieQjeXqU+jZxTqMkaqKZ8jKhildJgr8vNeLbOIgl2FtQEWv2ktXhQ=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-24", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-VqM628GsVtxdHM9ywucpRtaa/fUKHplGrkWRgmHBg/Ue+D75CCeihk/QUxAs4qhWaJYJwCCteja+htozr6PgPQ=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-25", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-fqOmmEuQ8qd8gpsXacO3aE7EPy5QT+oWGhDZGWVB3LnuIgEX4N4/8G+SxK0sEJuCHT3J5+4BGVjz3YUJvGvHfQ=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

`noUnusedImports`のlintルールをBiome設定に追加し、依存関係のロックファイルを更新します。

雑務：
- `biome.json`で`noUnusedImports`ルールを有効化
- 更新された設定を反映するために`bun.lock`を再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add the `noUnusedImports` lint rule to the Biome configuration and update dependencies lock file

Chores:
- Enable `noUnusedImports` rule in `biome.json`
- Regenerate `bun.lock` to reflect the updated configuration

</details>