### PR TITLE
build: 🆙 version up dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -264,27 +264,27 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.1", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.96", "", {}, "sha512-Jd3T8D67NLxuGA0VQPTQ//FL+TAhdLmF6Gmjf1lt1AOilPKZC1q74w72Or/UcKUD0sP43USjxYmoGxsM/104iA=="],
+    "@next/env": ["@next/env@15.4.0-canary.97", "", {}, "sha512-zWw/QZyWiGBpaLwxqsLoq18rIk6Q4F2xFUMWiLUAFt5VKFyMgt7FLyudLAjUxlCr7y8mUuzxsjMgWAso9+jozQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.96", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yncd3D2jWAzkXt4ufZX8FqLoaEck9e4YQXsDuM0D1azjFKT2pjfzO/M6c30wp8cyhkHIVyt0aJAbzSWbPvxAZA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.97", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iZXn7zOW0K/65dJI5GPpuHUHoXfoI3OmkeRsUe/9wMPg3l2cLNu4797WrxcXw1SbO5OhNbmK5u8XvasCN25Mng=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.96", "", { "os": "darwin", "cpu": "x64" }, "sha512-acddSWDcVUW7qrJAwOMQxBH5biL8AE+Leb1jABGUujdU5hbaaDfwNNpNDSzADa8RE129Y6wja7IznWkFvgExRg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.97", "", { "os": "darwin", "cpu": "x64" }, "sha512-l2TQZUJV+PXrRSQz5SQ4x+EV5HQzhUhe6VjVmJv7YVpWmXBIKfDv2MWlcs83BCKi8MPj2u7TeVhvX+8z8qX/Gw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.96", "", { "os": "linux", "cpu": "arm64" }, "sha512-989F8/83vjzQliPXK0gIo7Dk6+Kb/pE+hv0ZH41k5vBMZ/04sskQCBs4qUY6jOtXIPnWqyHub00ZAEg8nyZAjQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-Oxj2+6X3KoKgur1nL/wNjoEUwbeQnA6CyzkM6AJRUpBP3ZUPAA1uLOL06f5wO0T5Yyn7TPka1H1/ZyakHC4DEQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.96", "", { "os": "linux", "cpu": "arm64" }, "sha512-Br7nyXFFRvXk6gZUNtXLLY6fID04UaL8jzTh5dlYXw1U0z/0ornK8rmEBMqB/OFj+9WOD9kCaMOJwTTZVMlzAw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.97", "", { "os": "linux", "cpu": "arm64" }, "sha512-I2ItCheWHMBMZVbLiEDJTpSQNwrGb2vCPxUWmZvMjXHdjFAVGBhGELMxDq5hNjWb4COYd7eMA5bJ096MYBooZQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.96", "", { "os": "linux", "cpu": "x64" }, "sha512-aWca6MVS0kHX9QUtsDtfCLSCzdesGTNNu8SXJgb6IfJpC6eGvpfeRPo1vJlMEdr47vfME+urljmLKdOx+oscrg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.97", "", { "os": "linux", "cpu": "x64" }, "sha512-oQDUh60oqBGNNe4YZzE7D3i8NrZ/DY5z7XTmJm8K4qJknxvtLFUneo9Wog2HBIhY1ryTP3GvosqBItBv5NNkGA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.96", "", { "os": "linux", "cpu": "x64" }, "sha512-MREPMctlEZH7vYnE8dwan/LVGbj38sgDiAUdbIRp4djDdRyqr+74010JzIqO0ilveUPM0jCCVjaY/aN0sDuzEw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.97", "", { "os": "linux", "cpu": "x64" }, "sha512-KbT71w/zz/bvc1EuoeR62Txzec/H9+duhTjwZ7O+l6XsJZv2RxFpjpeuNjRuNMhlq825BKRqWCPpFLEpyEvnvA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.96", "", { "os": "win32", "cpu": "arm64" }, "sha512-Aa3i7b1hFsAiXMqyTZ4mb2suJgTAg8SAVfZUKFICQoigUm2y2Qb/9A6Tbo+fONPpW6UDT8+UVliuTXlIW6IJtw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.97", "", { "os": "win32", "cpu": "arm64" }, "sha512-6TOzvZ0dPSYakDLXI9ozOswQxCQZ2pMXPwW1wbO5Nr/J/e1eJnDyXeJ/7a3eCrRazivnzyw8x2ZADbGibR0bsw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.96", "", { "os": "win32", "cpu": "x64" }, "sha512-53GhrpVMZLnqxckeTvtS/ZP2rMPuqgpD+zqWKGUo3kwiQxQ2uEYJqKZrnlzB0gGoBG0S1xgaiGNSrI8o95I4fw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.97", "", { "os": "win32", "cpu": "x64" }, "sha512-9eGj5tYr6sUeMfQLjgN9GTnGe74aVQEaUdzFaO+JPG+MSg6z5O689Qx1TFc9qOi7YWMPafLzsN3/GXEXb8X3UA=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-25", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-25" }, "bin": { "playwright": "cli.js" } }, "sha512-H2r8OiDis2iLlbkRNwDsuube6H8gr+BLNc90szA8ARMsPRTlmsVgxvs6gOE+A4aDvHNPpZUF3igUKleRg+zrAQ=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-26", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-26" }, "bin": { "playwright": "cli.js" } }, "sha512-TusNKFsE7Rq7SkOSGWfXoM3h1vzQtPzZZU+ZUofyP26VSuuyMr9wRET3LRTtZYPW0UzRjjXLHz4y4379UuObMw=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -544,7 +544,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.0-canary.96", "", { "dependencies": { "@next/env": "15.4.0-canary.96", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.96", "@next/swc-darwin-x64": "15.4.0-canary.96", "@next/swc-linux-arm64-gnu": "15.4.0-canary.96", "@next/swc-linux-arm64-musl": "15.4.0-canary.96", "@next/swc-linux-x64-gnu": "15.4.0-canary.96", "@next/swc-linux-x64-musl": "15.4.0-canary.96", "@next/swc-win32-arm64-msvc": "15.4.0-canary.96", "@next/swc-win32-x64-msvc": "15.4.0-canary.96", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-CbiGuPnjA3jtoxtecKbe9r/PL4QKpUvj4N4wCWs3SuJDQanxXnNcnmGnxEPrCHyvxWJbRFRv0Q0yaVijcpi1iw=="],
+    "next": ["next@15.4.0-canary.97", "", { "dependencies": { "@next/env": "15.4.0-canary.97", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.97", "@next/swc-darwin-x64": "15.4.0-canary.97", "@next/swc-linux-arm64-gnu": "15.4.0-canary.97", "@next/swc-linux-arm64-musl": "15.4.0-canary.97", "@next/swc-linux-x64-gnu": "15.4.0-canary.97", "@next/swc-linux-x64-musl": "15.4.0-canary.97", "@next/swc-win32-arm64-msvc": "15.4.0-canary.97", "@next/swc-win32-x64-msvc": "15.4.0-canary.97", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-bpPpivhPtoiyojP6dLViqmEuU169kNXT8TZvCCbdvsA5eDO0KeoHm2DTu9DBYBAwcD7EH+i7qINLkVe1yvzMGg=="],
 
     "next-auth": ["next-auth@5.0.0-beta.29", "", { "dependencies": { "@auth/core": "0.40.0" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0-0", "nodemailer": "^6.6.5", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A=="],
 
@@ -562,9 +562,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-25", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-25" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wYnvf++6p+41IuZdu8yK8ELfltrOrGQQIieQjeXqU+jZxTqMkaqKZ8jKhildJgr8vNeLbOIgl2FtQEWv2ktXhQ=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-26", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-26" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-1+Fn2bXexEUGhowxnc3+Df/SFvpyXDtMm+z8tmqp2+oqX2Uu5ELwGE7IHkrZZpS6WnLdfYUbECxOBiBP2kKNeQ=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-25", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-fqOmmEuQ8qd8gpsXacO3aE7EPy5QT+oWGhDZGWVB3LnuIgEX4N4/8G+SxK0sEJuCHT3J5+4BGVjz3YUJvGvHfQ=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-26", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-vHYIQqkXEwJiTNDz0G1rE/BoBnnHD9OHA1UXJK4/4AaYKdVa+EI3IV74iXycoBy0MWTRF09q01CVIyltbBMeLA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/OpenUp-LabTakizawa/dcrs/pull/1026).
* __->__ #1026
* #1024

## Sourcery によるサマリー

@aws-sdk/client-s3 を最新のパッチバージョンに更新し、それに応じてロックファイルを更新します。

機能拡張:
- @aws-sdk/client-s3 を v3.835.0 から v3.837.0 にアップグレード

雑務:
- 更新された依存関係を反映するために biome.json と bun.lock を再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump @aws-sdk/client-s3 to the latest patch version and update lockfiles accordingly

Enhancements:
- Upgrade @aws-sdk/client-s3 from v3.835.0 to v3.837.0

Chores:
- Regenerate biome.json and bun.lock to reflect updated dependencies

</details>