### PR TITLE
build: change base image to node from bun for turbopack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.17.1-labs
 # check=error=true
-FROM oven/bun:canary AS builder
-WORKDIR /usr/src/app
+FROM node:24 AS builder
+WORKDIR /app
+RUN npm install -g bun@canary
+
 RUN --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=bun.lock,target=bun.lock \
   --mount=type=cache,target=/root/.bun \
@@ -16,9 +18,9 @@ FROM gcr.io/distroless/nodejs24-debian12:nonroot
 WORKDIR /app
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 
-COPY --from=builder /usr/src/app/public ./public
-COPY --from=builder /usr/src/app/.next/standalone ./
-COPY --from=builder /usr/src/app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
 
 EXPOSE 3000
 ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000


### PR DESCRIPTION
## Sourceryによるサマリー

Turbopackのビルド環境をBunベースのイメージから公式のNode 24イメージに切り替え、Bun canaryをnpm経由でインストールし、それに応じて作業ディレクトリとコピーパスを更新します。

ビルド：
- ビルダーのベースイメージを oven/bun:canary から node:24 に切り替え
- ビルダーステージで bun@canary をnpm経由でグローバルにインストール
- WORKDIR を更新し、COPY のソースパスを /usr/src/app から /app に調整

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the Turbopack build environment from a Bun-based image to the official Node 24 image, install Bun canary via npm, and update working directory and copy paths accordingly

Build:
- Switch the builder base image from oven/bun:canary to node:24
- Install bun@canary globally via npm in the builder stage
- Update WORKDIR and adjust COPY source paths from /usr/src/app to /app

</details>