### PR TITLE
chore: remove `useSortedClasses` rule due to error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,9 +11,6 @@
       "correctness": {
         "noUnusedImports": "error"
       },
-      "nursery": {
-        "useSortedClasses": "error"
-      },
       "style": {
         "noUselessElse": "error",
         "useBlockStatements": "error"

--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-26", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-26" }, "bin": { "playwright": "cli.js" } }, "sha512-TusNKFsE7Rq7SkOSGWfXoM3h1vzQtPzZZU+ZUofyP26VSuuyMr9wRET3LRTtZYPW0UzRjjXLHz4y4379UuObMw=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-27", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-27" }, "bin": { "playwright": "cli.js" } }, "sha512-HXEZ8/4G7UZjxYFI3KwvrkwzYOvTCr7KYcM8l0FHG1f1sk8s62Epuaa9xSvbs2ghE69tKzg/AOlxwpRHXLLo0g=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -562,9 +562,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-26", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-26" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-1+Fn2bXexEUGhowxnc3+Df/SFvpyXDtMm+z8tmqp2+oqX2Uu5ELwGE7IHkrZZpS6WnLdfYUbECxOBiBP2kKNeQ=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-27", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-27" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/RPQch6zxtstmFVZCKG8IKYk+Ztlb21eL4AUhV1rcS/2uFvXtQ9i9nYb6/KVYptPLJacTrCXZp4toCPL95fv6Q=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-26", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-vHYIQqkXEwJiTNDz0G1rE/BoBnnHD9OHA1UXJK4/4AaYKdVa+EI3IV74iXycoBy0MWTRF09q01CVIyltbBMeLA=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-27", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-lPG/vPS1znnmZ4bAg/vKgLOCynICXlK4r+xAOEolcr+vhLq+hHhwYk15dFyhxhvRaluvnEbj6VUz3mS4keWdEA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

雑務：
- `useSortedClasses` ルールエントリを biome.json から削除し、リント構成のエラーを防ぎます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove the `useSortedClasses` rule entry from biome.json to prevent errors in the lint configuration.

</details>