### PR TITLE
test: add missing className to Mock Image

### DIFF
--- a/happydom.tsx
+++ b/happydom.tsx
@@ -38,11 +38,20 @@ const mapNextImageSrcToString = (
 function MockNextImage({
   alt,
   height,
+  className,
   src: nextImageSrc,
   width,
 }: Readonly<ImageProps>): ReactElement {
   const imgSrc: string = mapNextImageSrcToString(nextImageSrc)
-  return <img alt={alt} height={height} src={imgSrc} width={width} />
+  return (
+    <img
+      alt={alt}
+      className={className}
+      height={height}
+      src={imgSrc}
+      width={width}
+    />
+  )
 }
 
 mock.module("next/image", (): EsModuleDefault<ComponentType<ImageProps>> => {


### PR DESCRIPTION
## Sourceryによるサマリー

バグ修正:
- `MockNextImage`の`className`プロパティを、Next.jsの`Image`の挙動に合わせて、レンダリングされた`<img>`要素に伝播させるように修正しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Propagate the className property in MockNextImage to the rendered <img> element to match Next.js Image behavior.

</details>