### PR TITLE
docs: add StackBlitz Codeflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://react-hook-form.com/"><img src="https://img.shields.io/badge/react%20hook%20form-EC5990?labelColor=000000&logo=reacthookform&style=for-the-badge" alt="React Hook Form"></a>
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/tailwind%20css-06B6D4?labelColor=000000&logo=tailwindcss&style=for-the-badge" alt="Tailwind CSS"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-3178C6?labelColor=000000&logo=typescript&style=for-the-badge" alt="TypeScript"></a>
+  <a href="https://pr.new/github.com/OpenUp-LabTakizawa/dcrs"><img src="https://img.shields.io/badge/stackblitz-207BEA?labelColor=000000&logo=stackblitz&style=for-the-badge" alt="StackBlitz"></a>
   <a href="https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/OpenUp-LabTakizawa/dcrs"><img src="https://img.shields.io/badge/open-007ACC?label=dev%20containers&labelColor=000000&style=for-the-badge" alt="Dev Container"></a>
   <a href="https://github.com/OpenUp-LabTakizawa/dcrs/blob/main/LICENSE"><img src="https://img.shields.io/github/license/OpenUp-LabTakizawa/dcrs?labelColor=000000&style=for-the-badge" alt="License"></a>
 
@@ -139,6 +140,7 @@ This software uses the following open source packages:
 - [Playwright](https://playwright.dev/)
 - [React](https://react.dev/)
 - [React Hook Form](https://react-hook-form.com/)
+- [StackBlitz Codeflow](https://stackblitz.com/codeflow/)
 - [Tailwind CSS](https://tailwindcss.com/)
 - [TypeScript](https://www.typescriptlang.org/)
 


### PR DESCRIPTION
## Sourcery によるサマリー

StackBlitz Codeflow のバッジを追加し、プロジェクトの README に参照を追加します。

ドキュメント：
- StackBlitz Codeflow のバッジを README.md のバッジセクションに追加しました。
- StackBlitz Codeflow をオープンソースの依存関係のリストに含めました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add StackBlitz Codeflow badge and reference to the project README

Documentation:
- Add StackBlitz Codeflow badge to the badges section in README.md
- Include StackBlitz Codeflow in the list of open source dependencies

</details>