### PR TITLE
chore(commit): update commit types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,9 @@ The [Commit Message Footer](#commit-message-footer) format describes what the fo
   │       │             │
   │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
   │       │
-  │       └─⫸ Commit Scope: biome|bun|ci|common|css|docker|git|security|test|vscode ...
+  │       └─⫸ Commit Scope: biome|bun|common|css|docker|git|security|vscode ...
   │
-  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
+  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
 ```
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
@@ -138,8 +138,9 @@ Must be one of the following:
 * **fix**: A bug fix
 * **perf**: A code change that improves performance
 * **refactor**: A code change that neither fixes a bug nor adds a feature
+* **revert**: Reverts a previous commit
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 * **test**: Adding missing tests or correcting existing tests
-* **upgrade**: Version up
 
 ##### Scope
 
@@ -153,7 +154,6 @@ The following is the example list of supported scopes:
 * `git`
 * `npm`
 * `security`
-* `test`
 * `vscode`
 * etc ...
 

--- a/bun.lock
+++ b/bun.lock
@@ -263,27 +263,27 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.1", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.109", "", {}, "sha512-vKnaI019Ah/NFWQVsVT+o2Bd7immpS7vthEQTfUvfT5oBAdq68YUGyxYm425kc+Kt6U/kLzXsnLIApB5LH3Ayw=="],
+    "@next/env": ["@next/env@15.4.0-canary.110", "", {}, "sha512-gTa2y/kELUJzAk3JeyD3/oOHHF/rnOIJfXqbFvOJK63m1XB3aghRKtZIClJkZm9oAVD+v4CNvWm1EkzLURjMBg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.109", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JvQeD/MCummEDSc9yayhwi5tTceEJZrdFV4hsxXPRjiAVMJCeuWUYHsxnWphGvpTDnHssBq/dy7DOVTc3VzDTw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.110", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ZVG5IlSn6INofGUWRMYJSBIP6Mkm+PEWuf9LrxevPN3Akzi9Hb3ntbHxrYL9THhq4b5J3eJNGzGb0ziNeh/9wA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.109", "", { "os": "darwin", "cpu": "x64" }, "sha512-vVFGcVTiThg9rILwTf0dZZ/Bfab+n3YIGGa0Ry2mVN2fNvP4VqmHjTcIJMqtS26SxQhyeSW8qRb9TLQYgrw3TQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.110", "", { "os": "darwin", "cpu": "x64" }, "sha512-RFSMNLjxkY79W98z7CMvbacVoPdfEB/shm6ngCSBgQ2pj8iWW+c+IjdDATbcgF+vbX5OnjNhP3nvSq7mKX8ajg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.109", "", { "os": "linux", "cpu": "arm64" }, "sha512-+b5otVq6aeicWqSRL3guAQr3ihXYgNbXpXbxu2WYc9Klzf1Kauq6azWJTMB6q8DbVITpLPqSt79JInrijFG/1A=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.110", "", { "os": "linux", "cpu": "arm64" }, "sha512-eOX3aGxWmwnfJG+4WCZ1jH+nm+heYa9aGGw11SH3Av6pE+hRXo+CB7Vd3rZWlFvrZVb2wkaAl3sCuADE9oJndA=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.109", "", { "os": "linux", "cpu": "arm64" }, "sha512-hEnzZ9eq/5cSy1F5+aeFs2jyi5DsQc2HYM1JhOLtNdhCoWlBayOvYroIkpRZtnsVLHNG5MEB8+8TbdMZFxv16w=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.110", "", { "os": "linux", "cpu": "arm64" }, "sha512-GhT7nLi8kvUriGYpqnrHeOVPO/Ul1We8FaBHfJF/m1ZvLmKwQKtyenhCSD/Qqb7mCqkJ++KCcFFPvlj6GI+KVg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.109", "", { "os": "linux", "cpu": "x64" }, "sha512-2Lf28v9WMIVzdBo6anDg3DPu3GxgczTWQU3lGgdfBYNTsiAZJar4YsU/4oy/zV3hlNgqAH8xEpOTp3fA+nzipA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.110", "", { "os": "linux", "cpu": "x64" }, "sha512-90xBpEnQFRG8ADX+wA9wczV2swGhrmrvxRY6k2MUQ5lIPYcFp7HJPyO/Btu/SbwIlbsXvpSuZm6ECC7Ek9PfNA=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.109", "", { "os": "linux", "cpu": "x64" }, "sha512-YCrVMlFwU45i4l6xk70htIw8p+e4/0E8FUgRXDsiZDy0e2etfkfBifxFqAmmlCsQipsVolZDHqgg5VZU6BGK9w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.110", "", { "os": "linux", "cpu": "x64" }, "sha512-7uGDJTQjPC6FLhBhZZ4taRyO5seH81oWrAEjGjSGpNQs2YCJ2CaC/xK1DZWiQQBrLNg0a0XuU7DUw6Tw0uuONA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.109", "", { "os": "win32", "cpu": "arm64" }, "sha512-ouq4DBtAEo19yWTG2cGWLVP8+mbOPKjNRTs8t3x6XfDrObB3UX+gv1F9fnUFm8gwPtdjyf7jOoxoQ3iwNvpvdA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.110", "", { "os": "win32", "cpu": "arm64" }, "sha512-+ezQ9hHmF2ShPIJjsggWsbOB8Sgw+7j1HurkaIbr1nnUQ3t+ufSV4uJgiEF41jO8a8RrF0RiNiRrraKqcqXMGQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.109", "", { "os": "win32", "cpu": "x64" }, "sha512-zeRWV+fBmCCfFJgEUlC9JwcTxmwu37PT2088CxKiIm6+M1+nGhilAmMpwD39tTTQSHR2UeT1Orff9ANcMqlYjQ=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.110", "", { "os": "win32", "cpu": "x64" }, "sha512-vvZT994B+JHt/1DG7lgvUJYhwJUKU3u4uetFOTrY7Y1KEQj4lw4T+ON5gT6ai4UliLwkegGcAjj7Zvc3MFOD5g=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-07-02", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-07-02" }, "bin": { "playwright": "cli.js" } }, "sha512-F/fkSi0LuAE9z52N3bn5KC+/A8huaFgeEWCvmMRO0k5JWnhBtpao/DNbBjxDUNnWk71Kq06jSJJpe68CXEy9gg=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-07-03", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-07-03" }, "bin": { "playwright": "cli.js" } }, "sha512-TUDven8XgPOiLOymRBVOI+0AEqWhFqrPCVYunOtV0KQ28Pxi3E1LqicsjYONAb4raASkrpti3HZas792XZreQw=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -543,7 +543,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.0-canary.109", "", { "dependencies": { "@next/env": "15.4.0-canary.109", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.109", "@next/swc-darwin-x64": "15.4.0-canary.109", "@next/swc-linux-arm64-gnu": "15.4.0-canary.109", "@next/swc-linux-arm64-musl": "15.4.0-canary.109", "@next/swc-linux-x64-gnu": "15.4.0-canary.109", "@next/swc-linux-x64-musl": "15.4.0-canary.109", "@next/swc-win32-arm64-msvc": "15.4.0-canary.109", "@next/swc-win32-x64-msvc": "15.4.0-canary.109", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-tGOri9fXTh4GZ78I0JOOrwnylMCEaX3aJPmCXK3X6EYs4mVo343SWPKnqy0B9mx0mk7O0dzOiXzVb+GQMEIpyA=="],
+    "next": ["next@15.4.0-canary.110", "", { "dependencies": { "@next/env": "15.4.0-canary.110", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.110", "@next/swc-darwin-x64": "15.4.0-canary.110", "@next/swc-linux-arm64-gnu": "15.4.0-canary.110", "@next/swc-linux-arm64-musl": "15.4.0-canary.110", "@next/swc-linux-x64-gnu": "15.4.0-canary.110", "@next/swc-linux-x64-musl": "15.4.0-canary.110", "@next/swc-win32-arm64-msvc": "15.4.0-canary.110", "@next/swc-win32-x64-msvc": "15.4.0-canary.110", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-ge2pEGXz5BjAgUObxHP03EPDHSV43lgE9hceF6APs9MWxM/MP+xdQdNrjV6cXkl6sVZkWDqPRipir6TUHd0J9w=="],
 
     "next-auth": ["next-auth@5.0.0-beta.29", "", { "dependencies": { "@auth/core": "0.40.0" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0-0", "nodemailer": "^6.6.5", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A=="],
 
@@ -561,9 +561,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-07-02", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-07-02" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-U5T7NgKkV+tvEuVE+Gfery2YFQwziqiVAT22xBphYMpgaFrzm+BzBwfmWiEnsr2XWHy7KxcJPpL/tqmrn4xCuw=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-07-03", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-07-03" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-tvSmV4TBnWx0VIP00eCpMtidwq3Rvrhf2q3vCGcUbvu3ZL+rOnS8u9A1P8fegtpNn9wD3zjKEH8t+2zTNtyZMA=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-07-02", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-V8rXokrUFs6oGMN1Vr6WPqzqk105ZFd8fLyv+iNsii7k+QAlKcJu6+fP2XwmxngSN5u/31JHVFLSF4IIERKPZw=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-07-03", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-IMFLP1fphDgjquRL4K/pg0enGL5pXnF9ukUK9EOmuQ+I9nhNsl8TA1UaEMqDAkomjar5ev9cU0au76hoJ6Q10g=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourcery によるサマリー

コミットメッセージの規約を更新しました。CONTRIBUTING.md のタイプとスコープを調整し、依存関係のロックファイルを更新しました。

ドキュメント:
- 新しいコミットタイプ (chore, revert, style) を追加
- obsolete な upgrade タイプをコミットタイプリストから削除
- ci と test をコミットスコープとサポートされているスコープのリストから削除

雑務:
- `bun.lock` ファイルを再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update commit message conventions by adjusting types and scopes in CONTRIBUTING.md and refreshing dependencies lockfile

Documentation:
- Add new commit types: chore, revert, and style
- Remove obsolete upgrade type from commit types list
- Remove ci and test from commit scopes and supported scopes lists

Chores:
- Regenerate bun.lock file

</details>