### PR TITLE
ci: remove biome github reporter

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun update
 
       - name: 🔷 Run Biome
-        run: bun check && bun biome ci --reporter=github
+        run: bun check
 
       - name: 💾 Commit
         uses: autofix-ci/action@v1.3.2


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- Autofix ワークフローから `bun biome ci --reporter=github` ステップを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove `bun biome ci --reporter=github` step from the Autofix workflow

</details>