### PR TITLE
build: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.17.1-labs
 # check=error=true
-FROM oven/bun:canary AS builder
+FROM oven/bun:1.2.19 AS builder
 WORKDIR /usr/src/app
 RUN --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=bun.lock,target=bun.lock \

--- a/bun.lock
+++ b/bun.lock
@@ -267,27 +267,27 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.1", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA=="],
 
-    "@next/env": ["@next/env@15.4.2-canary.16", "", {}, "sha512-rSLh+IMkAPKjIUYQrH3UCl3D/Xcq/X5w+rppo7rv8D+aw/19ODieNFC8e2NtUZ1uBP6SxlTrmn9E5rwX+YRdXg=="],
+    "@next/env": ["@next/env@15.4.2-canary.17", "", {}, "sha512-uyjRy+8e8donxAEjAxzPSfWK1GsqOKpCtv7TlAAX2JrmYXJ1WReg8hu6x2UDkfNEScMxGDjKc7B25NBoyKnhJw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XL0KWYWcc5C3BYefpmkdwOoMe4qMwYyyC70dSqY2F6evq/tJksFZFazul6seD5xx/p0nta7PgJRiQOiKCQdpwQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ErYKnjmkqtsOZLS0jdUWWJDZ1GSyU58IVqfhT3/s0hZMmS9VAoEsgOV77IJ5/Kk02CdzPpMOg8+Ec945VxdqZw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-iF16S+JGjrGv9OSWxywmfLgq/M/pLRDBrlUxAqjk6U15uK8gq0IVzuGyL0qNDTtrDiadsscGmigCJGOEwdm1eQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-H0o829p0e8t8zTxAGOATAFB0Y6ajDYzlKziHt2TDruYVcc+RdFMtUyHindVzNoaDYihNMrJsSlETnj6qn6yZsg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-Idc5TemlKFOuafEKXA6qFmpv/t9S9yfi17KEK3YoNpfALUtX9fgpZ99X+ADuQixYK6sItB7gTKChfNctiVPlsQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-TbGLq2VvKqfdbggC20doDzHJhB1liKWeqggdbSHICShH9sECBpBQZVj6yW7m5kcpjJ83Ty/lCEwSYQums8xaNg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-yNYoDIJWsygiLtnQ4zewadY5TyqnIu8+jcTVHmhHeDWJFaviBmrvt/U7IcuWBtQwpMYBCshVMKRlqWHTNDWhpw=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-7Wuu8mDEGFBz3tPVXBUWENYYb2031qUaB0N+Gqv3IpD/DsbpwZIk77OZx22dNMZ1eyszP6cDN++mj0Fj79cWnA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.16", "", { "os": "linux", "cpu": "x64" }, "sha512-T85erPFUJpmHTRlAy4V1BBbRe8WFk0uC7DTFkPafTXSshk5ww2an+FrpoTtKUTlXESq+CNzXpb80ZAlpYagRCQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.17", "", { "os": "linux", "cpu": "x64" }, "sha512-sXnz3V8HnYpE5kbOKGeRWQG1SvDnl7OYcoabf8z6FvslnOcH2gMeD1pVq5ndyh5fMGw7iEFhnE8upllGjoaB4g=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.16", "", { "os": "linux", "cpu": "x64" }, "sha512-dZdmfyavwZy7b0o8hCCGrOAZHBj+RWdVtI/vGijGxte910WQtUquVccu7W14htL2FNe5yFcsSWFW74Dy5Nli3Q=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.17", "", { "os": "linux", "cpu": "x64" }, "sha512-ATwGF/UwZ0xPRsIEgqyMQE0sZLME/C8XQElZhVkpoh8cxm82D/98AD/BPxueZJ7CoQEK6ut6Ib4XhO4jRv/89A=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-xvRQXTqSZ8JljsLwlVf1fcwTZjTXpHj4YbcE8aG2Lze3kt/xFo8QGEX9BT1kTCETM/hx14paIBlPY8zLey/rLQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-DaDS+h0d+06z3FojPV20wRJE3UokBrNy/8glqQDKldg5EWUf5N53UJ2hJ9CviMTgNUZ5hC0mBgjBRGfCzfVBhg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.16", "", { "os": "win32", "cpu": "x64" }, "sha512-ESWrS/3Xc96B8NYqCWjIJRfe0BQMxxWUXl5j7YoIdsriFWQdBjo0zyxX+m7SvSuyV5v5+kVWOMpU5R07KfllKQ=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.17", "", { "os": "win32", "cpu": "x64" }, "sha512-GXobi2ylY3LMt78wE01+d45JqwJg5zqxgvsxQmABlzYxKtBJSmsUDqlsYNdL1U2Ijg022XdOogwMgIfBZL+jaA=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-07-25", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-07-25" }, "bin": { "playwright": "cli.js" } }, "sha512-/q29rSorxuNcBlf18h+is1UeV8JZMYJQI+Y81KOU/L56o2jdkWDG78mnfT5+7vXbkCQfuokHgjhYA7zp9/6ixA=="],
+    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-07-26", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-07-26" }, "bin": { "playwright": "cli.js" } }, "sha512-9xp2W5yRyFy3t8e6D9vGJI7xtEfgMZ4H2pOj720bvK1gjR1P3xQQdkcwyUuQw0X6pt1S8phSU/EVR6r3duWxVw=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.4", "", { "dependencies": { "@smithy/types": "^4.3.1", "tslib": "^2.6.2" } }, "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA=="],
 
@@ -547,7 +547,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.2-canary.16", "", { "dependencies": { "@next/env": "15.4.2-canary.16", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.16", "@next/swc-darwin-x64": "15.4.2-canary.16", "@next/swc-linux-arm64-gnu": "15.4.2-canary.16", "@next/swc-linux-arm64-musl": "15.4.2-canary.16", "@next/swc-linux-x64-gnu": "15.4.2-canary.16", "@next/swc-linux-x64-musl": "15.4.2-canary.16", "@next/swc-win32-arm64-msvc": "15.4.2-canary.16", "@next/swc-win32-x64-msvc": "15.4.2-canary.16", "sharp": "^0.34.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.15.1", "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-woAb2J7LNgYQ1nJ7eWfTrC8UHSwU6PRUrfRNx5KtoCHUX4B4W7zwC6Pbza3vaKgexG2/eWUzGF+Fi7qnb5yGNA=="],
+    "next": ["next@15.4.2-canary.17", "", { "dependencies": { "@next/env": "15.4.2-canary.17", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.17", "@next/swc-darwin-x64": "15.4.2-canary.17", "@next/swc-linux-arm64-gnu": "15.4.2-canary.17", "@next/swc-linux-arm64-musl": "15.4.2-canary.17", "@next/swc-linux-x64-gnu": "15.4.2-canary.17", "@next/swc-linux-x64-musl": "15.4.2-canary.17", "@next/swc-win32-arm64-msvc": "15.4.2-canary.17", "@next/swc-win32-x64-msvc": "15.4.2-canary.17", "sharp": "^0.34.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.15.1", "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-gWOsaCUnrlEv83XseVowKyAL6yI/C3S24ZEi17hGSNCa1i3b215igsiUy/5nFWD4geai+bmx8tmcD1dFX9FGvw=="],
 
     "next-auth": ["next-auth@5.0.0-beta.29", "", { "dependencies": { "@auth/core": "0.40.0" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0-0", "nodemailer": "^6.6.5", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A=="],
 
@@ -565,9 +565,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.55.0-alpha-2025-07-25", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-07-25" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-T4kCSEvB7LkzyjEf/ik76++e7+Y4y7Q6b+9Av6cIm7gQqEPwbeNHdqYni6VcGIdifZP5TAuAEi5YW8wXJ7kADA=="],
+    "playwright": ["playwright@1.55.0-alpha-2025-07-26", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-07-26" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wxgJlDSeHQIsZSwKm8xfIESuZyIVr5H7z2GIE/7T5hPGbVWizL89mK4SqoYQcs/Gc8eUvd69uEqsCwovsOlyqg=="],
 
-    "playwright-core": ["playwright-core@1.55.0-alpha-2025-07-25", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-o+ySkkICbuGwO/LYZLBMAaEAPh/zeKwX3HKyazAsMJrufjzzy7Eo1XQurMbKI5KN6xdDa3fKd1dJpcsg4ze2+w=="],
+    "playwright-core": ["playwright-core@1.55.0-alpha-2025-07-26", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-lk861ClqsXsR7o57oGur/a+9/bUZHbaiOqM7a00GDONtcvNZt6Z3le8zVyWHWCPWr5sKRAR/PZV9hnT3y3V4Lw=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourceryによる要約

BunベースのDockerイメージをバージョン1.2.19に固定し、新しいランタイムに合わせるためにロックファイルを更新しました。

ビルド:
- Dockerfileを更新し、canaryの代わりに`oven/bun:1.2.19`を使用するようにしました
- 更新された依存関係を反映するために`bun.lock`を再生成しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin the Bun base Docker image to version 1.2.19 and update the lockfile to align with the new runtime

Build:
- Update Dockerfile to use oven/bun:1.2.19 instead of canary
- Regenerate bun.lock to reflect updated dependencies

</details>