### PR TITLE
ci: use success or failure condition

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -68,7 +68,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: commitlint
-    if: always() && github.event_name == 'pull_request'
+    if: success() || failure() && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -58,7 +58,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: lint-title
-    if: always()
+    if: success() || failure()
 
     steps:
       - name: ❌ Create test failed comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: test
-    if: always() && github.event_name == 'pull_request'
+    if: success() || failure() && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment


### PR DESCRIPTION
## Sourceryによる要約

CIワークフローを更新し、アップロードジョブで`always()`の代わりに`success()`または`failure()`の条件を使用するようにしました。

CI:
- commitlint、pull-request-title-lint、testの各ワークフローにおけるアップロードジョブで、`if: always()` を `if: success() || failure()` に置換
- commitlintとtestのアップロードジョブでは、`github.event_name == 'pull_request'` フィルターを維持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to use success() or failure() conditions for upload jobs instead of always().

CI:
- Replace `if: always()` with `if: success() || failure()` in upload jobs across commitlint, pull-request-title-lint, and test workflows
- Retain the `github.event_name == 'pull_request'` filter on the commitlint and test upload jobs

</details>