### PR TITLE
ci: fix condition

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -68,7 +68,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: commitlint
-    if: success() || failure() && github.event_name == 'pull_request'
+    if: (success() || failure()) && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: test
-    if: success() || failure() && github.event_name == 'pull_request'
+    if: (success() || failure()) && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment


### PR DESCRIPTION
## Sourceryによる要約

CIワークフローの条件におけるブール論理を修正し、アップロードジョブが`pull_request`イベントでのみ実行されるようにしました。

CI:
- `commitlint`ワークフローにおいて、`success() || failure()`式を括弧で囲み、正確に評価されるようにしました。
- `test`ワークフローにおいて、`success() || failure()`式を括弧で囲み、正確に評価されるようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix boolean logic in CI workflow conditions to ensure upload jobs only run for pull_request events.

CI:
- Wrap success() || failure() expressions in parentheses for accurate evaluation in commitlint workflow
- Wrap success() || failure() expressions in parentheses for accurate evaluation in test workflow

</details>