### PR TITLE
build: version up dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@tailwindcss/postcss": "^4.1.11",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
-        "@types/bun": "^1.2.19",
+        "@types/bun": "^1.2.20",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "daisyui": "^5.0.50",
@@ -287,7 +287,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-09", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-09" }, "bin": { "playwright": "cli.js" } }, "sha512-kLIguGg6aaqnIkOC8JmwX/ww9/+uuvCKzTrpR+EIWx1cSxfSGayWwtn6e/LhkZmcXeBaxU2MIK9xTl8rIJ65KA=="],
+    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-10", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-10" }, "bin": { "playwright": "cli.js" } }, "sha512-2CUtOnsT89fxsZHM1XkpzcZidDoxlRKqy8BqeVvdxMavLRQnnA+ZWGcCvCUuh50TDHTW5I0MQvZMHPRjkFkyhw=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.5", "", { "dependencies": { "@smithy/types": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g=="],
 
@@ -427,7 +427,7 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
+    "@types/bun": ["@types/bun@1.2.20", "", { "dependencies": { "bun-types": "1.2.20" } }, "sha512-dX3RGzQ8+KgmMw7CsW4xT5ITBSCrSbfHc36SNT31EOUg/LA9JWq0VDdEXDRSe1InVWpd2yLUM1FUF/kEOyTzYA=="],
 
     "@types/node": ["@types/node@20.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q=="],
 
@@ -451,7 +451,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
+    "bun-types": ["bun-types@1.2.20", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-pxTnQYOrKvdOwyiyd/7sMt9yFOenN004Y6O4lCcCUoKVej48FS5cvTw9geRaEcB9TsDZaJKAxPTVvi8tFsVuXA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001712", "", {}, "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig=="],
 
@@ -561,9 +561,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.55.0-alpha-2025-08-09", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-09" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hMpeIref3mq/jxqinSdM6nmXHUVhMsoegjP9snUtuO+yDT3qFH0v+jM1H/xjy7EPTmfPHzVFHlFga0OiPZUpCA=="],
+    "playwright": ["playwright@1.55.0-alpha-2025-08-10", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-10" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-k22f9wPBdL9pn4XE1xyKOJegHViGsoZP9MtXw/7tPkVE4+oPX1xZ/z8jZl2Xyi+pGLKms4wkhZzrpow/QIbLdA=="],
 
-    "playwright-core": ["playwright-core@1.55.0-alpha-2025-08-09", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-JeKI2gGxO44lllNwi6SF+MNnqsdl3ANQafqlwIUUjXGFT8fVjFCupjM1vyffRZakFsRkeqOAHJ+Oj2tnSNfUlQ=="],
+    "playwright-core": ["playwright-core@1.55.0-alpha-2025-08-10", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Kndm4ipJ4hXLP9xmuERQj70kj9PJq/Y9vfKgLN0BpCjTNi1L+lW9e+vhXryRXN2Z28lIIM9oDcohLS/2YnJl+A=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@tailwindcss/postcss": "^4.1.11",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@types/bun": "^1.2.19",
+    "@types/bun": "^1.2.20",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "daisyui": "^5.0.50",


### PR DESCRIPTION
## Sourceryによる要約

メンテナンス:
- @types/bun を 1.2.19 から 1.2.20 に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Update @types/bun from 1.2.19 to 1.2.20

</details>