### PR TITLE
fix: change modal type

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
   modal,
-}: Readonly<{ children: ReactNode; modal: JSX.Element }>): JSX.Element {
+}: Readonly<{ children: ReactNode; modal: ReactNode }>): JSX.Element {
   return (
     <html lang="ja" className={sawarabi.variable}>
       <body className="font-sawarabi">


### PR DESCRIPTION
## Summary by Sourcery

機能強化:
- モーダルプロップの型を`JSX.Element`から`ReactNode`に変更し、柔軟性を向上

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Change modal prop type from JSX.Element to ReactNode for improved flexibility

</details>