### PR TITLE
ci: disable persist-credentials

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,6 +82,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           ref: ${{ env.SHA }}
 
       - name: 🐋 Login to Docker Hub

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,6 +58,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           ref: ${{ env.SHA }}
         env:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
@@ -34,7 +35,6 @@ jobs:
           ignores: [(message: string) => message.includes("Signed-off-by: dependabot[bot]")] }' > commitlint.config.ts
 
       - name: 👀 Validate PR title with commitlint
-        if: github.event_name == 'pull_request'
         id: commitlint
         env:
           TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: ✅ Check if the release has already been created
         run: echo RELEASE_EXISTS=$(gh release list | grep "$VERSION") >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@v2

--- a/bun.lock
+++ b/bun.lock
@@ -287,7 +287,7 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-08-21", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-08-21" }, "bin": { "playwright": "cli.js" } }, "sha512-62k9YZNxHVbIQAaifzcTTimPeg8KzswHkZyui5V5vcnTn+kSJAnoo+7exKoWd0jJ0/sb0aViBLVzClV4cBrnwA=="],
+    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-08-22", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-08-22" }, "bin": { "playwright": "cli.js" } }, "sha512-jv/dMV08jCda5WxuiAUpllRuv7V2paAFq37cf44OIHeesnYvYvn9O2eIB/n6A0Oco1km05axgmMyy7t2Ey2NIA=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.0.5", "", { "dependencies": { "@smithy/types": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g=="],
 
@@ -561,9 +561,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.56.0-alpha-2025-08-21", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-08-21" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Sur6hvcyArvKLODg3dJ3/30cGJU2u62jy9ojxvi1nCJ64LPp8YqNqyNXKtjveMJ2hxysdPuEu7dRR/V5pO8rqg=="],
+    "playwright": ["playwright@1.56.0-alpha-2025-08-22", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-08-22" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/6yqK+3MejUmT7k0dBX4fFx82BshwJR03nIhA3GDgwLbsh5ZnZt1Sc7+eMn1u+jZHRTcCmYRgdixNk7AuCXj7A=="],
 
-    "playwright-core": ["playwright-core@1.56.0-alpha-2025-08-21", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-W/cH/Dj+VITiPA8RrFKW2BsFcjvoX5ZmQLSgKC3GZ2V1wA7vXuDM3fhZKhfbevtF9NxERSDSRd70IMkga3pXeg=="],
+    "playwright-core": ["playwright-core@1.56.0-alpha-2025-08-22", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-CL+ReEkOnVtrR/zlrUlLJfUWSMowulbsRDcQ2GnBTVLVJX/ks8A9c8zxef/tS070Eu/SMgIUeqW4zWmLgC7wXA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 


### PR DESCRIPTION
## Sourceryによる要約

すべてのワークフローでGitHub Actionsのチェックアウトにおけるpersist-credentialsを無効化し、PRタイトルリンティングにおけるPR専用フィルターを削除

CI:
- すべてのワークフローファイルでactions/checkoutにpersist-credentials: falseを追加し、自動的な認証情報永続化を防ぐ
- commitlintステップにおけるpull_requestイベントに対する条件チェックを削除し、すべてのイベントでPRタイトル検証を実行する

<details>
<summary>Original summary in English</summary>

## Sourceryによる要約

すべてのGitHub Actionsワークフローで自動的な認証情報永続化を無効にし、すべてのイベントでPRタイトルのリントを強制する

CI:
- すべての `actions/checkout` ステップに `persist-credentials: false` を追加
- すべてのイベントでタイトル検証を実行するために、`commitlint` から `pull_request` イベントの条件を削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable automatic credential persistence in all GitHub Actions workflows and enforce PR title linting for every event

CI:
- Add persist-credentials: false to all actions/checkout steps
- Remove pull_request event condition from commitlint to run title validation on all events

</details>

</details>