### PR TITLE
feat: enable `typedRoutes` config

### DIFF
--- a/app/components/layout/breadcrumb.tsx
+++ b/app/components/layout/breadcrumb.tsx
@@ -17,10 +17,17 @@ export function Breadcrumb({
         </li>
         {crumbs.map((crumb) => (
           <li key={crumb.name}>
-            <Link href={crumb.href || ""}>
-              <crumb.icon className={`mr-1 size-4 ${crumb.color}`} />
-              {crumb.name}
-            </Link>
+            {crumb.href ? (
+              <Link href={crumb.href}>
+                <crumb.icon className={`mr-1 size-4 ${crumb.color}`} />
+                {crumb.name}
+              </Link>
+            ) : (
+              <>
+                <crumb.icon className={`mr-1 size-4 ${crumb.color}`} />
+                {crumb.name}
+              </>
+            )}
           </li>
         ))}
       </ul>

--- a/app/interfaces/index.ts
+++ b/app/interfaces/index.ts
@@ -1,8 +1,9 @@
+import type { Route } from "next"
 import type { ElementType } from "react"
 
 export type Index = {
   name: string
   icon: ElementType
   color: string
-  href?: string
+  href?: Route
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
     viewTransition: true,
   },
   output: "standalone",
+  typedRoutes: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
## Sourceryによる要約

Next.jsでtypedRoutesを有効にし、ルーティングの型付けとブレッドクラムのレンダリングを改善

新機能:
- 型安全なルーティングのために、next.config.tsでtypedRoutes設定を有効化

バグ修正:
- hrefを持たない項目が空のリンクとしてレンダリングされるのを防ぐため、Breadcrumbが条件付きでプレーンテキストをレンダリングするように修正

改善点:
- Index.hrefの型をstringからNext.js Routeに更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable typedRoutes in Next.js and improve route typing and breadcrumb rendering

New Features:
- Enable typedRoutes config in next.config.ts for type-safe routing

Bug Fixes:
- Prevent Breadcrumb from rendering items without href as empty links by conditionally rendering plain text

Enhancements:
- Update Index.href type from string to Next.js Route

</details>