### PR TITLE
build: version up dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@types/bun": "^1.2.21",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
-        "daisyui": "^5.1.7",
+        "daisyui": "^5.1.8",
         "drizzle-kit": "^0.31.4",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.13",
@@ -267,27 +267,27 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.0.1", "", { "dependencies": { "@types/node": "^22.15.30", "@types/pg": "^8.8.0" } }, "sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA=="],
 
-    "@next/env": ["@next/env@15.5.1-canary.29", "", {}, "sha512-osu5F0iIDCBwooKyAUdZXB0/QWlq4GOyCjCbHUyfOCJLE06h1Kv/reUnODenJbJ+YEDg0C0Lz3VvCVJBWbu8EQ=="],
+    "@next/env": ["@next/env@15.5.1-canary.32", "", {}, "sha512-nQ97mQaaP/7/fz+ld4oQvYONnnTWj00slVRFmacPX7hGIwlONffWPkUQMYpgLrzLqbvDjYAFYms3fWLy6oN8SA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.1-canary.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WQ0LSw7CN7wB3qrrcL/N/2dce9MNdfgLmGLu/nU9Eln3p1R8hdAPniriwGj0eXJ0/fUJmShvr/TSjH/t98jvFw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.1-canary.32", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nPvZIe2vF0fhP05AlWs+Imlof5KOSwqCTTxdJIIxbobzHcjJtEF47x8YqQZhOW6t99Q6HGzjoPjarGdmWa4nSg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.1-canary.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-IH+O3FlQD5I6HW/v9nSmXelRGsbtHxUaJoA9H8CNp6+sA6tTS5QiVEPbuPwIRBjE9ibzHA+L/PTFfoCD4XL6Uw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.1-canary.32", "", { "os": "darwin", "cpu": "x64" }, "sha512-tpP0xgCsG6lD7tbyQ8hUiG/4N5ulJxN+krZv4H1yfiFWkxKvB/sIq4sEZ70saGD76aayEEGPIa7fsYwrK86s0g=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.1-canary.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-Zq4JECFcbXMThWp9vOvaV6FZGhycPdeX4iypN+AvfhIFLsJ0IS742OCYEVF9YmIIGsQD8Mnw2zzzbVaci36EDw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.1-canary.32", "", { "os": "linux", "cpu": "arm64" }, "sha512-3xJ8V3pmnKMpgxBsqSCxEP6RZSKR7eOgssIfTt4zQjl4uHzcOwI2M2sPX9RgeKJGqQfy3sgPbDiMipOub8dY/w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.1-canary.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-awEAYoTQGxz2OZdrcnDeDJz95sLn5AbTTylY4qiY01joag9Ie42422dNv3bTPiIWkFJYpHogiyJGRFVufYACoA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.1-canary.32", "", { "os": "linux", "cpu": "arm64" }, "sha512-tHH8Lx/TM4iEXpReayaOtAqYpT6463R7WGh4e0RLi2lpcbZWm4mY/KWhSuZJ16lN3QbEGgELqW9B8S9rLi0MMg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.1-canary.29", "", { "os": "linux", "cpu": "x64" }, "sha512-l1gEOO9Ez47ej+BBSbIE2Kpg01fSDUtn85pmnpTsNemiWV02AjgLvo3Ejmp1FZZm8CZZxhxFacwaTt4+eSPIug=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.1-canary.32", "", { "os": "linux", "cpu": "x64" }, "sha512-HwKDo4rRaNUyJevt5nfOk2YJJHwUq6O+7/QLJuahYGWa2kwf9Hj3hTZs9rk0bvi6NXnYWzRcFAVVt7UKPhJmzQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.1-canary.29", "", { "os": "linux", "cpu": "x64" }, "sha512-PY/Reyfl4BLew6kT5PaXLyH6WMKB9U3VBubCBq257t0NJNxrw5TbdH62QEwR8vbuWIq+BLki/4guKeT2MPAzeg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.1-canary.32", "", { "os": "linux", "cpu": "x64" }, "sha512-IcYRNk66c/dGMMhia8YGfSOBUltjkMWeAEsPWAF0raRReyuR8fhcFQfyK3utkFVNAu4IKlOV7IJCztgAH3tFdA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.1-canary.29", "", { "os": "win32", "cpu": "arm64" }, "sha512-KzNTPD3ihGn52NVWncI3qbcwWpbtEP5Dk8F9MfLZhCObWC5GWzFgx+CCbNb5ZbrIBf9ouicfqtREvN/+Tz9Law=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.1-canary.32", "", { "os": "win32", "cpu": "arm64" }, "sha512-0oyVG7rhdf2/TQ+rk7uC4MPs2PdoDY5KPsDcx9kvCHuu0kyEBpIQP1XV+nWNSXHb9MDjyFp+z9zT9NIq2a0zmw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.1-canary.29", "", { "os": "win32", "cpu": "x64" }, "sha512-Kl+erya2d4PGFB34O8kCrD51bVbjyEBsXuE2kAWvObQ9y1xuKxwqBQagHZd8oBDqB6e9j5NSFChxVVcx9n8BuQ=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.1-canary.32", "", { "os": "win32", "cpu": "x64" }, "sha512-TcBQfUiK7G0N5zwWgiWZ9HlJhludYYWi4VB7JBeErt8eelSC3JfX6Xoc/v4oj7oJle1dPzlB1tqKX+ET9lGF6g=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
-    "@playwright/test": ["@playwright/test@1.56.0-alpha-1757090131000", "", { "dependencies": { "playwright": "1.56.0-alpha-1757090131000" }, "bin": { "playwright": "cli.js" } }, "sha512-DVyN8ScyBMPasnrcIN7RjltZl7YkJlFZcz9otXe4TwUMo6JYt98MMmcsGXWbKCe+sk4KsgUNx3gYZtAWRBfIzw=="],
+    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-09-07", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-09-07" }, "bin": { "playwright": "cli.js" } }, "sha512-2gifrvMMMscGUk/5wm/mEVxwuNEuuuZawRnzUP20Xli3TzS+xlznHsjGikYPmqXDHRz3sEOj0d971xS0I/Z5zA=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.1.0", "", { "dependencies": { "@smithy/types": "^4.4.0", "tslib": "^2.6.2" } }, "sha512-wEhSYznxOmx7EdwK1tYEWJF5+/wmSFsff9BfTOn8oO/+KPl3gsmThrb6MJlWbOC391+Ya31s5JuHiC2RlT80Zg=="],
 
@@ -469,7 +469,7 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
-    "daisyui": ["daisyui@5.1.7", "", {}, "sha512-XjP2N22lQjFdpH6C1dqCXI+O3stt6ELe8aRtRC/7iKtbRCGZRhgz2YlzPfTiDFm8QH8nEcI/i1MgwY8Im0Ii5A=="],
+    "daisyui": ["daisyui@5.1.8", "", {}, "sha512-MJd683sm8ydToKrPoY8q72cht4j2EKellmTex51alY7L4p782gUtXTAZwiMOZixeKda/qb/c94XgoyLWSm4VNg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -543,7 +543,7 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.5.1-canary.29", "", { "dependencies": { "@next/env": "15.5.1-canary.29", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.1-canary.29", "@next/swc-darwin-x64": "15.5.1-canary.29", "@next/swc-linux-arm64-gnu": "15.5.1-canary.29", "@next/swc-linux-arm64-musl": "15.5.1-canary.29", "@next/swc-linux-x64-gnu": "15.5.1-canary.29", "@next/swc-linux-x64-musl": "15.5.1-canary.29", "@next/swc-win32-arm64-msvc": "15.5.1-canary.29", "@next/swc-win32-x64-msvc": "15.5.1-canary.29", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-vODhHbimgIPIPfY/qlKCazWA52tEthX5WpJZ9fJnu0d1rwmCh7sohEG9V+/GhBHX40yd1OaxHPUU/LnJRs5pnQ=="],
+    "next": ["next@15.5.1-canary.32", "", { "dependencies": { "@next/env": "15.5.1-canary.32", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.1-canary.32", "@next/swc-darwin-x64": "15.5.1-canary.32", "@next/swc-linux-arm64-gnu": "15.5.1-canary.32", "@next/swc-linux-arm64-musl": "15.5.1-canary.32", "@next/swc-linux-x64-gnu": "15.5.1-canary.32", "@next/swc-linux-x64-musl": "15.5.1-canary.32", "@next/swc-win32-arm64-msvc": "15.5.1-canary.32", "@next/swc-win32-x64-msvc": "15.5.1-canary.32", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-PGAZFQbZ53dVpbUk3vKmwthsL5D691wu30da/7FL8AbXDn/q9qJCzL73UN4jaqi4Q5E6yn6vfsCJ1TYxb9MpQw=="],
 
     "next-auth": ["next-auth@5.0.0-beta.29", "", { "dependencies": { "@auth/core": "0.40.0" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "next": "^14.0.0-0 || ^15.0.0-0", "nodemailer": "^6.6.5", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-Ukpnuk3NMc/LiOl32njZPySk7pABEzbjhMUFd5/n10I0ZNC7NCuVv8IY2JgbDek2t/PUOifQEoUiOOTLy4os5A=="],
 
@@ -561,9 +561,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.56.0-alpha-1757090131000", "", { "dependencies": { "playwright-core": "1.56.0-alpha-1757090131000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-3G5jTso8FKB8iiha0aRsZy7T/oanxL7Hx/D3oK3FzM0K3fS0eUXPetzQk8elYz/ZwNPCpfYvXbzGzdaRiBKLFw=="],
+    "playwright": ["playwright@1.56.0-alpha-2025-09-07", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-09-07" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-xMv0MKDlAQmlk10oj7PFdewsfvrTEpsLUMRY04r83Qf4s67/7dCuz2zILW4qiYlEsnbh9S5gQxKhTFfkmfpuIQ=="],
 
-    "playwright-core": ["playwright-core@1.56.0-alpha-1757090131000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-kj4hYkv79zIqUjepNun3homv1h9jkn4CHUNyfV8tJotj6X1ypmIiox/smLm7Lcjg9wLexk4N/Sxx1mglrXlQeg=="],
+    "playwright-core": ["playwright-core@1.56.0-alpha-2025-09-07", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-b6DRJ4C4aoTUi8Ib3u34S0JKQE3Wl5OPfBSL2m7TiTWbrl8kEGQBeOn/1CgB462rGclvqLnzi45OrDdbtGaZOw=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/bun": "^1.2.21",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
-    "daisyui": "^5.1.7",
+    "daisyui": "^5.1.8",
     "drizzle-kit": "^0.31.4",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.13",


### PR DESCRIPTION
## Sourceryによる概要

daisyui の依存関係を更新し、ロックファイルを更新しました

ビルド:
- daisyui のバージョンを ^5.1.7 から ^5.1.8 へ更新

雑務:
- 更新された依存関係で bun.lock を再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump daisyui dependency and update the lockfile

Build:
- Update daisyui version from ^5.1.7 to ^5.1.8

Chores:
- Regenerate bun.lock with the updated dependency

</details>