### PR TITLE
chore: auto upgrade tools

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -299,23 +299,23 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.1.0", "", {}, "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="],
 
-    "@next/env": ["@next/env@16.3.0-canary.4", "", {}, "sha512-lYo9I8eeEe6MGkGIHiieD3cOVP8yUUlvnZst9674fKM+TafWmKrQVHFRD03ChwWHkKLyJiMOq53+fIbbTqd0Rg=="],
+    "@next/env": ["@next/env@16.3.0-canary.5", "", {}, "sha512-2d9optG3mMmgELz6DXFHqdSoT11dXIz6rlzjcStWjAFL+sRa0R8QQX7odNuJPa//i+YGhEScoec4T5CcWiJWEA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3k7kYxraNYvQba/V8hVv0agOahSUuQYv/6OK07qryqXK8l/wC2wNo/iSNMuwNyJnwzdANOaF6yyhZO0Gc0pIUw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2Ht2PgvE5s37L39TWst2Y64gn4mT1WhgVzykPzDf/zAjWgKiklFwvBEmUw6c/6narIARJoDTmyW5rF4B4LZA9w=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-jP1IPyAElk36WgSbXlPnwscVntvWgNalypr4yknPWTbozvYHwPg448pIChzqTjT24vY3Ao4szbMyaRQSkdOqUQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-bJ2BoqNZZo+mK/rkdGRvkZC4nS6Eq6dKYqAUnEYWOR9WT10PQcU//z9xJSoDpWYWfCpubngSVEkjqpXiUhMsnA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-p6OZhslmqr+q8YCKNLYetRiCkyOtKiCwHrceeA7MWaFXIrkDzb4+2xA+u6X7NKoX6WrJ8nKiJvAKk4zIFHJVNQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-5th20Yf2HlIvjA09DOIdPx5w7C5MmWxPnLSFr96Y6Vqrj1jCGVfU6g8TmxHVeus1RtqohvIxeO7rE7TNut3Yig=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fcZF1L74e3e9DKh5YziqCQQT6WMcFkkZTbHOfPs6PhXf0C9Wt4S5zCRYcF2xvkMPvpOsP0q5kvAu4ztd8YYNRA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ghy2CYNlcURs88E2N2W80wt0wng57hkHMX4a55DEiQzFTEK1K8mnxWyRbGcwLOWILJmyLwRn+x+fwehNBzIqXA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FvwaG5l7h0GkrUo2yHEbzMNJFwkkfsuATKzfaL8vYU91dlPQnqdIzhmVLE7/PQV1h7H4G5tleTwEREuZylLPVw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.5", "", { "os": "linux", "cpu": "x64" }, "sha512-htMLkprT48bnPTraxeI4+vjOrvZbmf9M2cqQWFfpbEaHdwV54bbxUl1hYw1krNp6PB4YBi4nuE0Pso2psfI17g=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.4", "", { "os": "linux", "cpu": "x64" }, "sha512-3uDJJW1ULfbIc9u/hJhQG3L75WZ4NyM4CSJWkzgt/WzLyuDxWY6OCsybhXwmOXZ0q9wd35eVUv2HgAbK8IfO0g=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.5", "", { "os": "linux", "cpu": "x64" }, "sha512-WMq5f5iB9KyoQQ2QkqjEli5I2HV1a4vlqNE3VAHpqfA6S0TuQOAXqut7YxPNm4Yvio2hnYvLQFcK4RQsPnFM/w=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-b/hjH0S0iEk+2ieCrUnI1YU2PVz4mKpjzcUxCAWa1JcAu3nC8wDVLw2k8w4Iy37raKtP41DbgSdbbKdUx2hA/Q=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-MeyDRAIXQ1hwP0ttq8tZ7GATPgLS581CZdYt7/5NqOP1A65OI7jrxZnMoGQNDRaIgaug22T9KfnyCAXsAwI/NQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.4", "", { "os": "win32", "cpu": "x64" }, "sha512-vXDyDHVc/+HlCKIR4qy2YciOoimBXUPRuGq/vYY6FPgOUIUVFHaneEigCjplmEfa1wYNakeIWyUH+waae8cyUw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.5", "", { "os": "win32", "cpu": "x64" }, "sha512-Jv4bUns6TVIwEGrB74zZOOyITE7c2GEkW5yfV0rew5nUaRmqd6V/wS/C3Luc6fSxmmyuY5nJCmw3wFS0AGl35w=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -327,7 +327,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
-    "@playwright/test": ["@playwright/test@1.60.0-alpha-2026-04-28", "", { "dependencies": { "playwright": "1.60.0-alpha-2026-04-28" }, "bin": { "playwright": "cli.js" } }, "sha512-Ag0fxGYEZ6H8NXsiL5wg5C4TXoQFhxgiY60lOKfzbXEOpLj9nbS42LXFDO0AjfHSo7reoY0SguxwUOovS7vmFg=="],
+    "@playwright/test": ["@playwright/test@1.60.0-alpha-2026-04-29", "", { "dependencies": { "playwright": "1.60.0-alpha-2026-04-29" }, "bin": { "playwright": "cli.js" } }, "sha512-ujtwFj5Lo2CTRUhASrONEyquEuWUm+BHRYcEOxtlIDR/Y23bk0esqTE1dC+N7O9BYBad4SIOJy55lbZ0dxO8+w=="],
 
     "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw=="],
 
@@ -605,7 +605,7 @@
 
     "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 
-    "next": ["next@16.3.0-canary.4", "", { "dependencies": { "@next/env": "16.3.0-canary.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.4", "@next/swc-darwin-x64": "16.3.0-canary.4", "@next/swc-linux-arm64-gnu": "16.3.0-canary.4", "@next/swc-linux-arm64-musl": "16.3.0-canary.4", "@next/swc-linux-x64-gnu": "16.3.0-canary.4", "@next/swc-linux-x64-musl": "16.3.0-canary.4", "@next/swc-win32-arm64-msvc": "16.3.0-canary.4", "@next/swc-win32-x64-msvc": "16.3.0-canary.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-zSjok12hXm1ux39HyVGmjpaNeoYzB5iYaKCd7phqH2P9nOqGSlw2H4LznQHAwE3N42M+c+cigKRpqYDCvjEhnA=="],
+    "next": ["next@16.3.0-canary.5", "", { "dependencies": { "@next/env": "16.3.0-canary.5", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.5", "@next/swc-darwin-x64": "16.3.0-canary.5", "@next/swc-linux-arm64-gnu": "16.3.0-canary.5", "@next/swc-linux-arm64-musl": "16.3.0-canary.5", "@next/swc-linux-x64-gnu": "16.3.0-canary.5", "@next/swc-linux-x64-musl": "16.3.0-canary.5", "@next/swc-win32-arm64-msvc": "16.3.0-canary.5", "@next/swc-win32-x64-msvc": "16.3.0-canary.5", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-cDlzuyF80Gpq6qDeeWsTVvvs8F/dWgOVIsNSYkah/x+Ey9l0W8QhHiogw0/rXt7JZ8XSklbNYJDX8yDWFT02zA=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
@@ -627,9 +627,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.60.0-alpha-2026-04-28", "", { "dependencies": { "playwright-core": "1.60.0-alpha-2026-04-28" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-GBz1IdaM2WcH55sHYYzn3EiWHVrGEiX48GHJgJ692aMqwOo2RNNiHmWSIXS+xTnkIUovRqq2XD0mqoqN4gpLxg=="],
+    "playwright": ["playwright@1.60.0-alpha-2026-04-29", "", { "dependencies": { "playwright-core": "1.60.0-alpha-2026-04-29" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-SHIamiIXOzTmaedz4s8RncbV6iYIL2DNcWbOc5Ga8yMo1rvBk6NMZ0cyx0ri/gQSGlzqaVmWEMmly94xy7refg=="],
 
-    "playwright-core": ["playwright-core@1.60.0-alpha-2026-04-28", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-53xqrMc9iXrFgIkO96+SpW6jNtGf572x+wYlJoaDfafOpDr0qcDoyTjlm8IkA7+5J5T9gPV5tnOHNOEBig6iWg=="],
+    "playwright-core": ["playwright-core@1.60.0-alpha-2026-04-29", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-z8nSnI2oBBmd2SskLhOdWbnqw6m1CSscJG8Q9o+Xf+c430SB/zvqaP/kO8UKvX7hQnGwc3q/cnaM0O+QIvQwOQ=="],
 
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 

--- a/mise.toml
+++ b/mise.toml
@@ -30,7 +30,7 @@ run = ["bun update", "bun i --linker=isolated", "mise deps"]
 auto = true
 
 [hooks]
-enter = ["mise i -q", "mise deps -q"]
+enter = ["mise upgrade -q", "mise deps -q"]
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Summary by Sourcery

雑務:
- 依存関係を同期する前に `mise upgrade` を実行するように、mise の enter フックを変更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Change mise enter hook to run `mise upgrade` before syncing dependencies.

</details>