### PR TITLE
chore: Allow unsafe PR checkout in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v7
         with:
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
           ref: ${{ env.SHA }}
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Docker ワークフローにおいて、checkout ステップで `allow-unsafe-pr-checkout` を `true` に設定し、unsafe PR checkout を有効化しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Enable unsafe PR checkout in the Docker workflow by setting allow-unsafe-pr-checkout to true on the checkout step.

</details>