### PR TITLE
fix(autofix.ci): apply automated fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -255,23 +255,23 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.1.0", "", {}, "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="],
 
-    "@next/env": ["@next/env@16.3.0-canary.81", "", {}, "sha512-JcV9f2nP/twZT4fRwV5E3o64t0+isP68Ubnj0Jlc3fu757rhZWv9oS495kQEJW0m6QP9qMXwJ7WLdxyTgpVcwA=="],
+    "@next/env": ["@next/env@16.3.0-canary.82", "", {}, "sha512-5lJZ+1MhuP0aETUNUFKd/cDbwePh23hFRx72rKQPkTXhSBWrRZx02QKLpIO8RZjJMz9BNd5kMkNLFmBGmvAMEQ=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.81", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pvjdPSXV0Bvb3D4ytJOzC7ccvoBbtJX6AjR/kUNjmE34EhYgpCSQAggY5D8D3p1pdf/fi8PNcjINRxHZ/PXSqQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.82", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dXqTP+1EQT07l8ZCgUVVbpyXQOgTleKm9Paqls9Cz1i369lXR9wlOXaLK0MPnqZ4JSm51tCy2HThieXM1obF0g=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.81", "", { "os": "darwin", "cpu": "x64" }, "sha512-7Va2O7e/hxRMImiXku2zugh16GHlqR6xiYBm6V4yjeHDWuNdvh3Qu/EF3MaLfq2kdYJM6WLM/tb6Uy8Sn+su3A=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.82", "", { "os": "darwin", "cpu": "x64" }, "sha512-iXSfQxiMknpZ6s0+t1J8T83w4n85jragYyANg6wkSOoYYKg5jntD+nNbb0x0XSiynUKTZNt7i0C3BSc1cn46Ig=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.81", "", { "os": "linux", "cpu": "arm64" }, "sha512-yxy3BkjFWx0V1tLp4JBUN48qJdSgaL4ZY/tkbgsbg2sHTKo6u3v8bIUylVs4Cc6nv+qnT6N7F/OTiUdBcxZ5iw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.82", "", { "os": "linux", "cpu": "arm64" }, "sha512-EcmwNZsBuTxlz+X54ptrUJ8dV0pIJQAbHVwSKYzPJTjgWocgknMs2wobArROv1RvL7Cmc/d5HRmGJd12o0I2HQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.81", "", { "os": "linux", "cpu": "arm64" }, "sha512-eE3UgT5F7m0bY0w4/LZ76t1WWesP2JxJYTiAZ+v3Y7VTqOpe9ic75HkYwke5mvu/Y8nkpNhdqX3Yrz+PkbIXLg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.82", "", { "os": "linux", "cpu": "arm64" }, "sha512-gEuUmDA4ssLHhyhLGfXivRGOVOKAR4IPmsgz5XxO6ArN6HQBp7UVZ9lXecfFH4E5vOqvqhkyy1Om5pDluoyHbw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.81", "", { "os": "linux", "cpu": "x64" }, "sha512-mVTX51e3H2JafY1p9as9oZujf9PapZnKtTOWQuzeH0CJNsuGsznUsG6NC+Kv94x8N9SR7CK8nZh82DVpZmUTQg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.82", "", { "os": "linux", "cpu": "x64" }, "sha512-ViXBUpBtdGABuHN2DYE4gZ7FRRBbDJ1a4OBX5D25n3hsVFNyhHueWtFDcVokk4O1g48+zumumd6N4hGIJZ+/Jw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.81", "", { "os": "linux", "cpu": "x64" }, "sha512-nqDeT2mp3eSTegVi4NjjAgtaPERap9QBdYb3fcdO5o8Qa/3Fy3UF5qgzgpffuC2m51tRbL5MtirOd+o0yVW10w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.82", "", { "os": "linux", "cpu": "x64" }, "sha512-xWJFWYl5eF95KBsHGuawJ6OPXwuIWzcb4h66q8AwzflYvvMIriuBQUEDXbMerIb48Lkeu1+0cTILIQWxo3D+ow=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.81", "", { "os": "win32", "cpu": "arm64" }, "sha512-ZqVUgapu49nnhKA4Ks0xBM75q3K4d3eMStjyV6ho/bHyu6uJ7JwGuJVIsbXyITLyVLB1v/n+6Ts6ucGt/E/Jfw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.82", "", { "os": "win32", "cpu": "arm64" }, "sha512-6V2CPyZOmzHcYReNb6ExXXUuyvrF+6mHRvvILBDUYC4/0LA+5wFZ90ZNAgjHyvkt7wuONyK77FL5Xu/3J3qy3Q=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.81", "", { "os": "win32", "cpu": "x64" }, "sha512-9mwDYTrDqIqRccUUW4XFgpIQPBRpzsNFGUBnzYHu9YIUjIfoH4aXFlQQyeVw1JpBZ2XRt22Xjw9xOVlpnk30Sg=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.82", "", { "os": "win32", "cpu": "x64" }, "sha512-crTJA1g3Efc0+NSD/fKODGbDjj5hEcxqxTE+ceph6ZLFnE/EvSAziVAZ2MGMJfiIlFMXrT1DwGomRFa1Y4koew=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
 
@@ -531,7 +531,7 @@
 
     "nanostores": ["nanostores@1.2.0", "", {}, "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg=="],
 
-    "next": ["next@16.3.0-canary.81", "", { "dependencies": { "@next/env": "16.3.0-canary.81", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.81", "@next/swc-darwin-x64": "16.3.0-canary.81", "@next/swc-linux-arm64-gnu": "16.3.0-canary.81", "@next/swc-linux-arm64-musl": "16.3.0-canary.81", "@next/swc-linux-x64-gnu": "16.3.0-canary.81", "@next/swc-linux-x64-musl": "16.3.0-canary.81", "@next/swc-win32-arm64-msvc": "16.3.0-canary.81", "@next/swc-win32-x64-msvc": "16.3.0-canary.81", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VThwyVNANYI8AGQ8sd/r1MD0O9APfy3i58SWTk5rIbOLU7619h3kgH5Z4zxFbJLuLyWjpcsOIULBV/uysQcRbw=="],
+    "next": ["next@16.3.0-canary.82", "", { "dependencies": { "@next/env": "16.3.0-canary.82", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.82", "@next/swc-darwin-x64": "16.3.0-canary.82", "@next/swc-linux-arm64-gnu": "16.3.0-canary.82", "@next/swc-linux-arm64-musl": "16.3.0-canary.82", "@next/swc-linux-x64-gnu": "16.3.0-canary.82", "@next/swc-linux-x64-musl": "16.3.0-canary.82", "@next/swc-win32-arm64-msvc": "16.3.0-canary.82", "@next/swc-win32-x64-msvc": "16.3.0-canary.82", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-fOsu30FeCPhwB3Nxte3hVlPLksCVlSmfKnkDxM+cJXMphvaqWuGaVovGFFnidNB8vv3S+/55zmZxcXofLDzEEg=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 


### PR DESCRIPTION
## Summary by Sourcery

雑務:
- 現在の依存関係の状態を反映するために、autofix ツールを使用して `bun.lock` を再生成しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regenerate bun.lock using autofix tooling to reflect the current dependency state.

</details>