### PR TITLE
fix: enable experimental.useTypeScriptCli for TypeScript 7

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -281,7 +281,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0-alpha-2026-07-13", "", { "dependencies": { "playwright": "1.62.0-alpha-2026-07-13" }, "bin": { "playwright": "cli.js" } }, "sha512-hXwzo/vFwJjcUl7up6ARuc1BXkWHcJl28JIkmizbRCqj3f0FPVLlaru1Ov3Eh+pITLVh6sv1W3RAqA8W4+9q7A=="],
+    "@playwright/test": ["@playwright/test@1.62.0-alpha-2026-07-14", "", { "dependencies": { "playwright": "1.62.0-alpha-2026-07-14" }, "bin": { "playwright": "cli.js" } }, "sha512-MSaJ6T8Ugq18HP6EjS7ZoqtsPDcPeDyxkoVgudmJfeHuT8PxHDtWjMkLpoyuS76m9QXi1kGHv8oqIDsYZrdEeA=="],
 
     "@smithy/core": ["@smithy/core@3.29.2", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw=="],
 
@@ -559,9 +559,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.62.0-alpha-2026-07-13", "", { "dependencies": { "playwright-core": "1.62.0-alpha-2026-07-13" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-ddzhR5k8rI5VnPxzrLENDZaf4JX5RVtBB5XoWcMEC8paVEyg7HziRTnW8pxfjObiwMttuuAjTfamkiVxEh50vg=="],
+    "playwright": ["playwright@1.62.0-alpha-2026-07-14", "", { "dependencies": { "playwright-core": "1.62.0-alpha-2026-07-14" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-D/w6xB/ehLorIhuTnjIj5TdG/D2+a5MpSMTqVXsEnzx/d3n+QN5OixveKLTLAYzyiWpveVRR+o1+3SB1+qNZFg=="],
 
-    "playwright-core": ["playwright-core@1.62.0-alpha-2026-07-13", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-N9RL+OvjdgsagiP/SZVW7raWT9htr8sgNloP8AemhtBT8c4nMabDSWkRjJHjkjYGyIBzley7UbA4nqEsbEvMMQ=="],
+    "playwright-core": ["playwright-core@1.62.0-alpha-2026-07-14", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-5UoDF7wsgIjMaMBQT+Qm/OczyHCNamxh2Q+JjS0z8YiM6bpwoeojSGpJ7rwLyI4eLo60pKZYb+c0AqLyUZsfcw=="],
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     isrFlushToDisk: false,
     viewTransition: true,
+    useTypeScriptCli: true,
   },
   output: "standalone",
   reactCompiler: true,

--- a/test/unit/api/users/route.test.ts
+++ b/test/unit/api/users/route.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test"
 import fc from "fast-check"
 import type { User } from "@/app/lib/schema"
+import type { UploadParams } from "@/app/lib/storage"
 
 const mockFrom = mock()
 const mockSelect = mock(() => ({ from: mockFrom }))
 
-const mockUpload = mock(async () => ({ url: "https://example.com/img.png" }))
+const mockUpload = mock(async (_params: UploadParams) => ({
+  url: "https://example.com/img.png",
+}))
 const mockDelete = mock(async () => {})
 const mockGet = mock()
 
@@ -151,7 +154,7 @@ describe("Users Route Handler", () => {
         mockInsert.mockClear()
 
         const dbModule = await import("@/app/lib/db")
-        db = dbModule.db as typeof db
+        db = dbModule.db as unknown as typeof db
         db.insert = mockInsert
       })
 
@@ -299,7 +302,7 @@ describe("Users Route Handler", () => {
         mockInsert.mockClear()
 
         const dbModule = await import("@/app/lib/db")
-        db = dbModule.db as typeof db
+        db = dbModule.db as unknown as typeof db
         db.insert = mockInsert
       })
 
@@ -344,7 +347,7 @@ describe("Users Route Handler", () => {
 
               await POST(request)
 
-              const expectedExt = filename.split(".").pop()
+              const expectedExt = filename.split(".").pop() ?? ""
               const expectedKey = `${employeeId}.${expectedExt}`
 
               expect(mockUpload).toHaveBeenCalledTimes(1)

--- a/test/unit/lib/db.property.test.ts
+++ b/test/unit/lib/db.property.test.ts
@@ -49,7 +49,9 @@ describe("Feature: dual-database-support, Property 1: Driver selection is determ
         }
 
         const db = await createDb()
-        const kind = (db.constructor as Record<symbol, string>)[entityKind]
+        const kind = (db.constructor as unknown as Record<symbol, string>)[
+          entityKind
+        ]
 
         if (dbType === "postgres") {
           expect(kind).toBe("NodePgDatabase")

--- a/test/unit/lib/db.test.ts
+++ b/test/unit/lib/db.test.ts
@@ -31,7 +31,9 @@ describe("createDb driver selection", () => {
     process.env.DB_TYPE = "postgres"
 
     const db = await createDb()
-    const kind = (db.constructor as Record<symbol, string>)[entityKind]
+    const kind = (db.constructor as unknown as Record<symbol, string>)[
+      entityKind
+    ]
 
     expect(kind).toBe("NodePgDatabase")
   })
@@ -41,7 +43,9 @@ describe("createDb driver selection", () => {
     process.env.DB_TYPE = "neon"
 
     const db = await createDb()
-    const kind = (db.constructor as Record<symbol, string>)[entityKind]
+    const kind = (db.constructor as unknown as Record<symbol, string>)[
+      entityKind
+    ]
 
     expect(kind).toBe("NeonHttpDatabase")
   })
@@ -51,7 +55,9 @@ describe("createDb driver selection", () => {
     delete process.env.DB_TYPE
 
     const db = await createDb()
-    const kind = (db.constructor as Record<symbol, string>)[entityKind]
+    const kind = (db.constructor as unknown as Record<symbol, string>)[
+      entityKind
+    ]
 
     expect(kind).toBe("NeonHttpDatabase")
   })

--- a/test/unit/lib/storage/s3-backend.test.ts
+++ b/test/unit/lib/storage/s3-backend.test.ts
@@ -124,7 +124,12 @@ describe("Feature: local-dev-environment, Property 1: S3Client custom endpoint c
 
         expect(s3.config.forcePathStyle).toBe(true)
 
-        const resolvedEndpoint = await s3.config.endpoint()
+        const resolvedEndpoint = await s3.config.endpoint?.()
+        expect(resolvedEndpoint).toBeDefined()
+        if (!resolvedEndpoint) {
+          return
+        }
+
         const url = new URL(endpoint)
         expect(resolvedEndpoint.hostname).toBe(url.hostname)
         expect(resolvedEndpoint.protocol).toBe(url.protocol)
@@ -255,7 +260,7 @@ describe("createS3Client unit tests", () => {
         secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
       },
       region: process.env.S3_REGION,
-      ...(endpoint && { endpoint, forcePathStyle: true }),
+      ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
     })
 
     // No custom endpoint: forcePathStyle is not set and endpoint config is undefined
@@ -276,11 +281,15 @@ describe("createS3Client unit tests", () => {
         secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
       },
       region: process.env.S3_REGION,
-      ...(endpoint && { endpoint, forcePathStyle: true }),
+      ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
     })
 
     expect(s3.config.forcePathStyle).toBe(true)
-    const resolved = await s3.config.endpoint()
+    const resolved = await s3.config.endpoint?.()
+    expect(resolved).toBeDefined()
+    if (!resolved) {
+      return
+    }
     expect(resolved.hostname).toBe("localhost")
     expect(resolved.port).toBe(9000)
   })

--- a/test/unit/proxy.test.ts
+++ b/test/unit/proxy.test.ts
@@ -81,7 +81,7 @@ describe("Authorization proxy access control", () => {
     await fc.assert(
       fc.asyncProperty(usersPathArb, fc.boolean(), async (path, hasSession) => {
         // Reset state
-        state.redirectPath = null
+        state.redirectPath = null as string | null
         state.nextCalled = false
 
         // Configure session

--- a/test/unit/scripts/dev-up.test.ts
+++ b/test/unit/scripts/dev-up.test.ts
@@ -41,7 +41,7 @@ describe("Feature: local-dev-environment, Property 3: Idempotent bucket creation
 
 describe("createBucketIfNotExists", () => {
   it("creates bucket when it does not exist", async () => {
-    const sendMock = mock(() => Promise.resolve({}))
+    const sendMock = mock((_command: unknown) => Promise.resolve({}))
     const client = createMockS3Client(sendMock)
     const consoleSpy = spyOn(console, "log").mockImplementation(() => {})
 


### PR DESCRIPTION
TypeScript 7 no longer exposes the compiler API that `next build`
relied on, so the "Running TypeScript" step failed with
"TypeScript 7.0.2 does not provide the compiler API required by
Next.js" and broke the Playwright webServer build.

- Enable `experimental.useTypeScriptCli` so Next.js type-checks via
  the TypeScript CLI (ref JamBalaya56562/blog#1076).
- Fix type errors newly surfaced by the CLI in unit tests:
  - type mock parameters so recorded call tuples are non-empty
  - cast through `unknown` for incompatible structural casts
  - guard possibly-undefined endpoint providers and object spreads

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Summary by Sourcery

TypeScript 7 向けに Next.js TypeScript CLI の型チェックを有効化し、より厳密な型安全性に対応するようテストを更新します。

New Features:
- Next.js の experimental 設定を構成し、TypeScript CLI を用いた型チェックを有効にします。

Enhancements:
- データベースおよびユーザーのルートに関するテストで、キャストの安全性を高め、オプション値にデフォルト値を設定することで、型の扱いをより厳密にします。
- S3 クライアントおよびプロキシ関連のテストを改善し、オプションのエンドポイント、オブジェクトスプレッド、null になり得る状態をより堅牢に扱えるようにします。
- テスト内のモック関数を調整し、型付きのパラメータを使用するとともに、記録された呼び出しタプルが空にならないように維持します。

Tests:
- ユニットテストおよびプロパティベーステストを更新し、TypeScript 7 の CLI 型チェックおよびより厳格な型チェックと互換性を持たせます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Next.js TypeScript CLI type-checking for TypeScript 7 and update tests for stricter type safety.

New Features:
- Configure Next.js experimental settings to type-check using the TypeScript CLI.

Enhancements:
- Tighten type handling in database and user route tests with safer casting and defaults for optional values.
- Improve S3 client and proxy-related tests to handle optional endpoints, object spreads, and nullable state more robustly.
- Adjust mock functions across tests to use typed parameters and maintain non-empty recorded call tuples.

Tests:
- Update unit and property-based tests to be compatible with TypeScript 7’s CLI type-checking and stricter type checks.

</details>