### PR TITLE
fix: drop removed experimental.viewTransition config flag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -283,7 +283,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0-alpha-2026-07-23", "", { "dependencies": { "playwright": "1.62.0-alpha-2026-07-23" }, "bin": { "playwright": "cli.js" } }, "sha512-cdSRaYNA9C7L/gJt7d/X43GqACHhXCBetC9NtOm48WSdQXHzqP7JvqvhFAdjaIm3fR/ORsRzStXrCQFfkpfpfA=="],
+    "@playwright/test": ["@playwright/test@1.63.0-alpha-2026-07-24", "", { "dependencies": { "playwright": "1.63.0-alpha-2026-07-24" }, "bin": { "playwright": "cli.js" } }, "sha512-1IFtAkizJNP52A92HpmgBlHxbMnUDXHrwuiZoZsv2Ty7i205lhWX2s7MN0znj8LnOiC0qwf2IGjNzNBARyzzUA=="],
 
     "@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
 
@@ -561,9 +561,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.62.0-alpha-2026-07-23", "", { "dependencies": { "playwright-core": "1.62.0-alpha-2026-07-23" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-v0mtpDynyrqnu6+L4HyNSChw6bX7LlcOF2LMp6+//V4oXRvyG16FAZZskOvzmOTRcnabNUhicvarDbT4aYcyeQ=="],
+    "playwright": ["playwright@1.63.0-alpha-2026-07-24", "", { "dependencies": { "playwright-core": "1.63.0-alpha-2026-07-24" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-3zu9j+h2Sjhv0ajevdgSp9n/M46EVvWPw63lXw4kqHi5p1+9bRw4VTKpz6Nn74/WrbeOdlNJ7NDH0OrM/zZsjw=="],
 
-    "playwright-core": ["playwright-core@1.62.0-alpha-2026-07-23", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-D0934egkm34bL+WTRoFNASM4x3lnCnQsOG+3JLuZDVcdpFaGTn2212SsfyGryYyrgKLoEIBmoHJxuO5XEakcUw=="],
+    "playwright-core": ["playwright-core@1.63.0-alpha-2026-07-24", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-CpDV1o9v+GIOsmA653G9ofH4Dhyr9l7VvScVOzVq7wGENbS90vYJtXdoMhFWaEHx9La7Vx0Sdgj2Y9LdJiL8EA=="],
 
     "postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,6 @@ const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
     isrFlushToDisk: false,
-    viewTransition: true,
     useTypeScriptCli: true,
   },
   output: "standalone",


### PR DESCRIPTION
## 原因 / Cause
`next: "canary"`(バージョン固定なし)が最新 canary **16.3.0-canary.95** に追随し、Next.js が inert（無効化済み）だった `experimental.viewTransition` フラグを削除（vercel/next.js#96098）。このため `next build` の型チェックが `TS2353` で失敗し、CI が壊れていました。

## 修正 / Fix
`next.config.ts` から `experimental.viewTransition: true` の1行を削除。フラグはすでに inert で、View Transitions はデフォルト有効のため、**機能は維持したまま**ビルドが復旧します。

## 検証 / Verification
- ローカルで `next build` の TypeScript 型チェックが通過することを確認
- React ネイティブ `<ViewTransition>` は引き続き動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

最新のカナリービルドとの互換性を回復するために、Next.js の設定から非推奨となった `experimental.viewTransition` フラグを削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove deprecated experimental.viewTransition flag from Next.js configuration to restore compatibility with the latest canary build.

</details>