### PR TITLE
fix: synchronize theme toggle state

### DIFF
--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -7,36 +7,52 @@ import {
   SunIcon,
 } from "@heroicons/react/24/outline"
 import { type JSX, useEffect, useRef, useState } from "react"
-import { themeChange } from "theme-change"
 import { BlockerLink } from "@/app/components/button/blockerLink"
 import { SignInModal } from "@/app/components/layout/signInModal"
 import { signOut, useSession } from "@/app/lib/auth-client"
 import { SITE_TITLE } from "@/app/lib/constant"
 
+type Theme = "light" | "dark"
+
 export function Header(): JSX.Element {
   const { data: session } = useSession()
-  const [theme, setTheme] = useState<"light" | "dark">("light")
+  const [theme, setTheme] = useState<Theme | null>(null)
   const dialogRef = useRef<HTMLDialogElement | null>(null)
   const [scrollY, setScrollY] = useState<number>(0)
   const headerHeight: number = 100
 
   useEffect(() => {
-    if (
-      !("theme" in localStorage) &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      localStorage.setItem("theme", "dark")
-    }
+    const documentTheme = document.documentElement.dataset.theme
+    const savedTheme = localStorage.getItem("theme")
+    const initialTheme =
+      documentTheme === "dark" || documentTheme === "light"
+        ? documentTheme
+        : savedTheme === "dark" || savedTheme === "light"
+          ? savedTheme
+          : window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light"
 
-    themeChange(false)
-    if (localStorage.getItem("theme") === "dark") {
-      setTheme("dark")
+    document.documentElement.dataset.theme = initialTheme
+    if (savedTheme === null && initialTheme === "dark") {
+      localStorage.setItem("theme", initialTheme)
     }
+    setTheme(initialTheme)
+  }, [])
 
-    window.addEventListener("scroll", () => {
-      setScrollY(window.scrollY)
-    })
-  })
+  useEffect(() => {
+    const handleScroll = (): void => setScrollY(window.scrollY)
+    handleScroll()
+    window.addEventListener("scroll", handleScroll, { passive: true })
+
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
+
+  function changeTheme(nextTheme: Theme): void {
+    document.documentElement.dataset.theme = nextTheme
+    localStorage.setItem("theme", nextTheme)
+    setTheme(nextTheme)
+  }
 
   return (
     <>
@@ -82,19 +98,21 @@ export function Header(): JSX.Element {
             <ArrowLeftStartOnRectangleIcon className="rotate-y size-10 text-accent" />
             ログアウト
           </button>
-          <label className="btn btn-ghost btn-square h-fit swap swap-rotate">
-            <input type="checkbox" />
-            <div
-              className={`${theme === "light" ? "swap-off" : "swap-on"}`}
-              data-set-theme="light"
-            >
+          <label className="btn btn-ghost btn-square h-fit">
+            <input
+              type="checkbox"
+              aria-label="ダークモード"
+              className="sr-only"
+              checked={theme === "dark"}
+              onChange={(event) =>
+                changeTheme(event.currentTarget.checked ? "dark" : "light")
+              }
+            />
+            <div className="theme-toggle-light flex flex-col items-center">
               <SunIcon className="size-10 text-warning" />
               ライト
             </div>
-            <div
-              className={`${theme === "dark" ? "swap-off" : "swap-on"}`}
-              data-set-theme="dark"
-            >
+            <div className="theme-toggle-dark flex-col items-center">
               <MoonIcon className="size-10 text-secondary" />
               ダーク
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,20 @@
   --font-sawarabi: "Sawarabi Gothic", sans-serif;
 }
 
+.theme-toggle-dark {
+  display: none;
+}
+
+html[data-theme="dark"] {
+  .theme-toggle-light {
+    display: none;
+  }
+
+  .theme-toggle-dark {
+    display: flex;
+  }
+}
+
 .fade-out-alert {
   animation: fade-out-alert 1.5s forwards;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { Sawarabi_Gothic } from "next/font/google"
+import Script from "next/script"
 import { ScrollToTop } from "@/app/components/button/scrollToTop"
 import { AlertBox } from "@/app/components/layout/alertBox"
 import { Footer } from "@/app/components/layout/footer"
@@ -20,9 +21,31 @@ export const metadata: Metadata = {
   description: SITE_TITLE,
 }
 
+const themeInitializationScript = `
+  (() => {
+    const savedTheme = localStorage.getItem("theme")
+    const theme =
+      savedTheme === "dark" || savedTheme === "light"
+        ? savedTheme
+        : window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+
+    document.documentElement.dataset.theme = theme
+    if (savedTheme === null && theme === "dark") {
+      localStorage.setItem("theme", theme)
+    }
+  })()
+`
+
 export default function RootLayout(props: LayoutProps<"/">): JSX.Element {
   return (
-    <html lang="ja" className={sawarabi.variable}>
+    <html lang="ja" className={sawarabi.variable} suppressHydrationWarning>
+      <head>
+        <Script id="theme-initialization" strategy="beforeInteractive">
+          {themeInitializationScript}
+        </Script>
+      </head>
       <body className="font-sawarabi">
         <ViewTransition>
           <NavigationBlockerProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "pg": "^8.22.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "theme-change": "^3.0.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.5",
@@ -620,8 +619,6 @@
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
-
-    "theme-change": ["theme-change@3.0.4", "", {}, "sha512-tPknw142u0yX7M63rXOU1gc2N3cw61iLUtuvh5OKxXTA4/B5SOXxOeS+JT8Ig14SCjs5T2rY41aLFDeTRclV5w=="],
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
+  agentRules: false,
   experimental: {
     inlineCss: true,
     isrFlushToDisk: false,

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "next": "canary",
     "pg": "^8.22.0",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8",
-    "theme-change": "^3.0.4"
+    "react-dom": "^19.2.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.5",

--- a/test/e2e/layout.test.ts
+++ b/test/e2e/layout.test.ts
@@ -15,8 +15,78 @@ test.describe("Header and Footer layout", () => {
   })
 
   test("header displays theme toggle", async ({ page }) => {
+    await expect(
+      page.getByRole("checkbox", { name: "ダークモード" }),
+    ).toBeAttached()
     await expect(page.getByText("ライト")).toBeVisible()
-    await expect(page.getByText("ダーク")).toBeVisible()
+    await expect(page.getByText("ダーク")).toBeHidden()
+  })
+
+  test("theme toggle stays synchronized after repeated changes", async ({
+    page,
+  }) => {
+    const toggle = page.getByRole("checkbox", { name: "ダークモード" })
+
+    for (let count = 0; count < 20; count += 1) {
+      const expectedTheme = count % 2 === 0 ? "dark" : "light"
+      await page
+        .getByText(expectedTheme === "dark" ? "ライト" : "ダーク")
+        .click()
+      await expect(page.locator("html")).toHaveAttribute(
+        "data-theme",
+        expectedTheme,
+      )
+      await expect(toggle).toBeChecked({ checked: expectedTheme === "dark" })
+      await expect
+        .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+        .toBe(expectedTheme)
+    }
+  })
+
+  test("uses the OS theme when no theme has been saved", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" })
+    await page.evaluate(() => localStorage.removeItem("theme"))
+    await page.reload()
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark")
+    await expect(
+      page.getByRole("checkbox", { name: "ダークモード" }),
+    ).toBeChecked()
+  })
+
+  test("a saved theme takes precedence over the OS theme", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" })
+    await page.evaluate(() => localStorage.setItem("theme", "light"))
+    await page.reload()
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light")
+    await expect(
+      page.getByRole("checkbox", { name: "ダークモード" }),
+    ).not.toBeChecked()
+  })
+
+  test("theme persists through navigation and toggles after scrolling", async ({
+    page,
+  }) => {
+    const toggle = page.getByRole("checkbox", { name: "ダークモード" })
+    await page.getByText("ライト").click()
+    await page.getByRole("link", { name: /障がい者手帳画像を提出/ }).click()
+    await page.waitForURL("/register")
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark")
+    await expect(toggle).toBeChecked()
+
+    await page.evaluate(() => {
+      window.scrollTo(0, document.body.scrollHeight)
+      window.dispatchEvent(new Event("scroll"))
+    })
+    await page.getByText("ダーク").click()
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light")
+    await expect(toggle).not.toBeChecked()
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+      .toBe("light")
   })
 
   test("footer displays copyright text", async ({ page }) => {


### PR DESCRIPTION
### What does this PR do?

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

Fixes an intermittent theme toggle desynchronization where the UI could appear stuck in dark mode after repeated toggles, navigation, and scrolling.

The root cause was that the header initialized theme-change and registered a new scroll listener after every render, while the React state, uncontrolled checkbox, html data-theme attribute, and localStorage value were updated independently.

This PR removes theme-change and makes the React-controlled toggle update the DOM theme and persisted value together. A beforeInteractive initialization script applies the saved theme or OS preference before hydration, CSS keeps the initial icon consistent, and scroll handling now uses a stable listener with cleanup. Next.js agent-rule auto-generation is disabled to avoid regenerated Markdown lint violations.

### How did you verify your code works?

I wrote automated tests covering repeated theme changes, state and localStorage synchronization, saved-theme precedence, OS preference initialization, navigation, and toggling after scrolling.

- `mise exec -- rumdl check AGENTS.md`
- `bunx biome check next.config.ts`
- `bunx tsc --noEmit`
- `bun test:unit` (69 passed)
- `bunx playwright test test/e2e/layout.test.ts --project=chromium` (9 passed)
- `bun run build`