### PR TITLE
test: remove mock

### DIFF
--- a/app/lib/create-db.ts
+++ b/app/lib/create-db.ts
@@ -1,0 +1,23 @@
+import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
+import type { NodePgDatabase } from "drizzle-orm/node-postgres"
+
+export type DbClient = NeonHttpDatabase | NodePgDatabase
+
+export async function createDb(): Promise<DbClient> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not set")
+  }
+
+  const connectionString = process.env.DATABASE_URL
+  const dbType = process.env.DB_TYPE ?? "neon"
+
+  if (dbType === "postgres") {
+    const { drizzle } = await import("drizzle-orm/node-postgres")
+    const { Pool } = await import("pg")
+    return drizzle(new Pool({ connectionString }))
+  }
+
+  const { neon } = await import("@neondatabase/serverless")
+  const { drizzle } = await import("drizzle-orm/neon-http")
+  return drizzle(neon(connectionString))
+}

--- a/app/lib/db.ts
+++ b/app/lib/db.ts
@@ -1,25 +1,9 @@
-import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
-import type { NodePgDatabase } from "drizzle-orm/node-postgres"
+import { createDb, type DbClient } from "@/app/lib/create-db"
 
-export type DbClient = NeonHttpDatabase | NodePgDatabase
+export type { DbClient }
 
-export async function createDb(): Promise<DbClient> {
-  if (!process.env.DATABASE_URL) {
-    throw new Error("DATABASE_URL is not set")
-  }
-
-  const connectionString = process.env.DATABASE_URL
-  const dbType = process.env.DB_TYPE ?? "neon"
-
-  if (dbType === "postgres") {
-    const { drizzle } = await import("drizzle-orm/node-postgres")
-    const { Pool } = await import("pg")
-    return drizzle(new Pool({ connectionString }))
-  }
-
-  const { neon } = await import("@neondatabase/serverless")
-  const { drizzle } = await import("drizzle-orm/neon-http")
-  return drizzle(neon(connectionString))
-}
-
+// `db` is deliberately the only runtime export: test files mock
+// "@/app/lib/db" to swap it out, and `mock.module` replaces the whole module
+// namespace. Keeping `createDb` in its own module means those mocks cannot
+// hide it from the tests that exercise it for real.
 export const db: DbClient = await createDb()

--- a/bun.lock
+++ b/bun.lock
@@ -258,23 +258,23 @@
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.1.0", "", {}, "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="],
 
-    "@next/env": ["@next/env@16.3.1-canary.1", "", {}, "sha512-lH486JAq5G4VDfdFcvDq4if14vSwWqER6xNf7KDUK3aV016Ye6/qVKSxU7e3+egWZ5acLBqEi999GgUQQ9RE4g=="],
+    "@next/env": ["@next/env@16.3.1-canary.3", "", {}, "sha512-12Io9yJY1X1AduWOENP0ZJPQS1uVTgXqpF9Qs8zbwNS5ZlrLGsm1Wk4JCSXILEgiXi/Aa6VY4hLZl7RAJScRYw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.1-canary.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4bGqVII+ZYEPU8QusZmpLaXUruRsLCJLNQaxWpDdEih1F0DMdw5B/CGGJUwCTcpaNVZkjXe5e89aEpbIIA6mfg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.1-canary.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XpFmov+Pv0ZeSu0bzxkLy5L7x9BnQNhcK3HE95LYEVP9DSZhwbU68ysfzUKB70hKvv6bRK7hnqDrEDQDJ9svJQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.1-canary.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-AQEBCo2YtAmzeiQxxwgrRbLzdsbOmgsM01H/tV5rLVYSoQ5ljASIvzd3ilrGllL/qo/pJ0z6WDkYAZHXXHy0Ew=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.1-canary.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-zeIkyXNhRSrMq2xOCDM3VKLLeiHmdF5nm2Xu1L7SK5NQsokg6iM1X4B00bfsU6iww4/Z+1sCBP7H97UH0DQ6aA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.1-canary.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-BJjzpklmzWtnlIsIH0BWskZ7ttIxP1SwxMeAEqO7Y2g7BlO7KFyKvFq7YKlW/ny8xRz6hWWz/MX406c+9RUIzQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.1-canary.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jN7Z4ih22W5zdkvxPLBKvqvljRs2+HTcgkvFTlPr3g2eZXuKPiOX2SS3ihgyLRiGnCs1aVu2mNowcgQietEfpw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.1-canary.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-EgYOyDItjHVddtfeww/JbYTY81zBBdxxTcF/80+aFAVYITRZEDirLSYyrxzODEqE59tbXmwIS+ag46Hw9k9j2w=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.1-canary.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-IwuNlmEXDElNvmITc073YWf+wRjU+iON6xb+xTbkm7Mtx4odMIkDPGbv9jNUTD6w0Iqv1RUPueti6w3q1X5ZDQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.1-canary.1", "", { "os": "linux", "cpu": "x64" }, "sha512-EaRLpOpl9KGZnq+/51isfl+a1+ImyjS3R2wG0g6YuASGsHQAqY5NpJLonaQCEX4TREmSP/pUefgdiUdiPSXmvA=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.1-canary.3", "", { "os": "linux", "cpu": "x64" }, "sha512-XArby/i2Cmp3LwKmymVHl8qYwbPjb3E0Z33jq5vlwcJgoG5pqYqZTaz2o2S+GBvi8ndVG0MGwJpLuydIXVHb3w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.1-canary.1", "", { "os": "linux", "cpu": "x64" }, "sha512-TnDsUh6mMOUkhLQRR3HBFBcJDgIzOfhE33XFyFnWaujjsIqWSLlcNgx1LvOEFxUv4wS1iXh2OGCGXweeyBsn1w=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.1-canary.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Dux8wojRLxdk17+KJMDrDumC2sPWSDDBfXVJeyQQ+DG7p9wC51oGdCyN9oNwV+EBbwRTfiIV8lVWwgfbcN9jMA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.1-canary.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-F9UDoyGC1fW0ZDjP5ajy0aD1Anhz0nkLCaYvuCM6l1LlhWG8HL/xGA2D59n4Ynh1/Dgyye7hsOqQ2hH4+xUDNw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.1-canary.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-tGQlBcKYq8igkPk9aovJThoPRS/EkUkoecJCxoJgH5jQ4jWrJ/aqDLD6n829eQMyoRzTt4E/6pX0INXvqs+ESA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.1-canary.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BW+USauqUv5EfwQQE2aQ7rXAm4MNyJwhN2r9C61tQG+R9AuWAuAPuZUFYfYziNxE61zf6OeWrtj6kQCxQGeP2w=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.1-canary.3", "", { "os": "win32", "cpu": "x64" }, "sha512-IfRD8H+JSZAXJybkpRiVg75Zv+3qjW39zQzbmZvjMumd+CPBbFlhtwHWiiTj/+D8EiU1Yj37TMmWkl05uZew3A=="],
 
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
@@ -282,7 +282,7 @@
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
-    "@playwright/test": ["@playwright/test@1.63.0-alpha-1785861467000", "", { "dependencies": { "playwright": "1.63.0-alpha-1785861467000" }, "bin": { "playwright": "cli.js" } }, "sha512-t0rsJWatpIHjX9NxoNLGFgrHFXr7FRCRxHEpLvWsdnohrorVAptxweJpz9fcgtQSI82RQvg6OWz2k3Rkeh2gQA=="],
+    "@playwright/test": ["@playwright/test@1.63.0-alpha-2026-08-05", "", { "dependencies": { "playwright": "1.63.0-alpha-2026-08-05" }, "bin": { "playwright": "cli.js" } }, "sha512-Q63UaqUDAAwdrGwYjvlLXsfltkUkmRqqwkZ7SSmY3qDGAH2gUcIHWvHauU5xnWhBrIVHej07sGUbErS3QL39tw=="],
 
     "@smithy/core": ["@smithy/core@3.31.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
 
@@ -532,7 +532,7 @@
 
     "nanostores": ["nanostores@1.4.0", "", {}, "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA=="],
 
-    "next": ["next@16.3.1-canary.1", "", { "dependencies": { "@next/env": "16.3.1-canary.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.1-canary.1", "@next/swc-darwin-x64": "16.3.1-canary.1", "@next/swc-linux-arm64-gnu": "16.3.1-canary.1", "@next/swc-linux-arm64-musl": "16.3.1-canary.1", "@next/swc-linux-x64-gnu": "16.3.1-canary.1", "@next/swc-linux-x64-musl": "16.3.1-canary.1", "@next/swc-win32-arm64-msvc": "16.3.1-canary.1", "@next/swc-win32-x64-msvc": "16.3.1-canary.1", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-dpZ/DGoVKnBKvTv2F/DMgoQnMQJoI8lN7WwA19DGCuH3MEigizI1nkAFDC4f1wTkiFKz1zSujtVcxQbfPaMD9A=="],
+    "next": ["next@16.3.1-canary.3", "", { "dependencies": { "@next/env": "16.3.1-canary.3", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.1-canary.3", "@next/swc-darwin-x64": "16.3.1-canary.3", "@next/swc-linux-arm64-gnu": "16.3.1-canary.3", "@next/swc-linux-arm64-musl": "16.3.1-canary.3", "@next/swc-linux-x64-gnu": "16.3.1-canary.3", "@next/swc-linux-x64-musl": "16.3.1-canary.3", "@next/swc-win32-arm64-msvc": "16.3.1-canary.3", "@next/swc-win32-x64-msvc": "16.3.1-canary.3", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-RhmxJevzKRqg3nQAoYLy/Xw5ECXxKfZDwHM8r69uugP7ERi0kXGWCHdvFia0LT/TXgkQLnAJc8fTf+bCG1bMBQ=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
@@ -560,9 +560,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.63.0-alpha-1785861467000", "", { "dependencies": { "playwright-core": "1.63.0-alpha-1785861467000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-5LNme+VZCogK1rpBbQ/tuYHTzgrp8Dlf/7HcNyKK2kyKMGHJyUWGGvulVTqDR6RAq6OtzeOIelpAk1p+nzAmxQ=="],
+    "playwright": ["playwright@1.63.0-alpha-2026-08-05", "", { "dependencies": { "playwright-core": "1.63.0-alpha-2026-08-05" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-zbGZUK+JYkoDV3cUgfvh2czTBJL34Gmz5gHVI25xiIpvYSR17Q1M7TS8hnwECUe+IkKaeXbKrSyJTyogm2DVWw=="],
 
-    "playwright-core": ["playwright-core@1.63.0-alpha-1785861467000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-X7qSBCAzTQkWBwZQGVAFLH/qrNY/4JO6k2WL7De//KpttNKKQPjnbsss0vWMQwDRftqEliUC2prkB5lb4GkljQ=="],
+    "playwright-core": ["playwright-core@1.63.0-alpha-2026-08-05", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-YussvUybTfBtyYbGXWh43f+5kNP03wg98M6mu4DphYET7PSbNVajsdLGjWE1xrsjqOw32i2wFlRP7U5mcOpMZg=="],
 
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "biome lint --write",
     "format": "biome format --write",
     "lint:fix": "biome check --write",
-    "test:unit": "bun test test/unit --preload ./happydom.ts",
+    "test:unit": "bun test test/unit --preload ./happydom.ts --isolate --randomize",
     "test:e2e": "playwright test",
     "test:report": "playwright show-report",
     "generate": "drizzle-kit generate",

--- a/test/unit/lib/db.property.test.ts
+++ b/test/unit/lib/db.property.test.ts
@@ -7,11 +7,7 @@ const entityKind = Symbol.for("drizzle:entityKind")
 const originalDbType = process.env.DB_TYPE
 const originalDatabaseUrl = process.env.DATABASE_URL
 
-// Ensure DATABASE_URL is set for module-level createDb() call in db.ts
-process.env.DATABASE_URL =
-  process.env.DATABASE_URL ?? "postgresql://user:pass@localhost:5432/testdb"
-
-const { createDb } = await import("@/app/lib/db")
+const { createDb } = await import("@/app/lib/create-db")
 
 describe("Feature: dual-database-support, Property 1: Driver selection is determined solely by DB_TYPE value", () => {
   afterEach(() => {

--- a/test/unit/lib/db.test.ts
+++ b/test/unit/lib/db.test.ts
@@ -6,11 +6,7 @@ const entityKind = Symbol.for("drizzle:entityKind")
 const originalDbType = process.env.DB_TYPE
 const originalDatabaseUrl = process.env.DATABASE_URL
 
-// Ensure DATABASE_URL is set for module-level createDb() call in db.ts
-process.env.DATABASE_URL =
-  process.env.DATABASE_URL ?? "postgresql://user:pass@localhost:5432/testdb"
-
-const { createDb } = await import("@/app/lib/db")
+const { createDb } = await import("@/app/lib/create-db")
 
 describe("createDb driver selection", () => {
   afterEach(() => {

--- a/test/unit/lib/storage/factory/index.test.ts
+++ b/test/unit/lib/storage/factory/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 
 class MockS3Backend {
   _type = "S3Backend" as const
@@ -8,17 +8,7 @@ class MockVercelBlobBackend {
   _type = "VercelBlobBackend" as const
 }
 
-mock.module("@/app/lib/storage/s3-backend", () => ({
-  S3Backend: MockS3Backend,
-}))
-
-mock.module("@/app/lib/storage/vercel-blob-backend", () => ({
-  VercelBlobBackend: MockVercelBlobBackend,
-}))
-
 // Replicate createStorageClient logic to test the selection behavior.
-// This must be inlined because mock.module factories cannot reference
-// variables defined after them (lazy evaluation + live bindings).
 function createStorageClient(): MockS3Backend | MockVercelBlobBackend {
   const token = process.env.BLOB_READ_WRITE_TOKEN
   if (token && token.trim() !== "") {
@@ -26,18 +16,6 @@ function createStorageClient(): MockS3Backend | MockVercelBlobBackend {
   }
   return new MockS3Backend()
 }
-
-// Override any previous mock of @/app/lib/storage from other test files
-// to ensure cross-test isolation (live bindings update all existing imports).
-mock.module("@/app/lib/storage/index", () => ({
-  createStorageClient,
-  storageClient: createStorageClient(),
-}))
-
-mock.module("@/app/lib/storage", () => ({
-  createStorageClient,
-  storageClient: createStorageClient(),
-}))
 
 describe("createStorageClient()", () => {
   let originalToken: string | undefined

--- a/test/unit/lib/storage/factory/storage.test.ts
+++ b/test/unit/lib/storage/factory/storage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import fc from "fast-check"
 
 class MockS3Backend {
@@ -9,17 +9,7 @@ class MockVercelBlobBackend {
   _type = "VercelBlobBackend" as const
 }
 
-mock.module("@/app/lib/storage/s3-backend", () => ({
-  S3Backend: MockS3Backend,
-}))
-
-mock.module("@/app/lib/storage/vercel-blob-backend", () => ({
-  VercelBlobBackend: MockVercelBlobBackend,
-}))
-
 // Replicate createStorageClient logic to test the selection behavior.
-// This must be inlined because mock.module factories cannot reference
-// variables defined after them (lazy evaluation + live bindings).
 function createStorageClient(): MockS3Backend | MockVercelBlobBackend {
   const token = process.env.BLOB_READ_WRITE_TOKEN
   if (token && token.trim() !== "") {
@@ -27,18 +17,6 @@ function createStorageClient(): MockS3Backend | MockVercelBlobBackend {
   }
   return new MockS3Backend()
 }
-
-// Override any previous mock of @/app/lib/storage from other test files
-// to ensure cross-test isolation (live bindings update all existing imports).
-mock.module("@/app/lib/storage/index", () => ({
-  createStorageClient,
-  storageClient: createStorageClient(),
-}))
-
-mock.module("@/app/lib/storage", () => ({
-  createStorageClient,
-  storageClient: createStorageClient(),
-}))
 
 describe("Feature: vercel-blob-storage, Property 1: Non-empty token selects VercelBlobBackend", () => {
   let originalToken: string | undefined


### PR DESCRIPTION
## Summary by Sourcery

データベースクライアントファクトリを専用モジュールに切り出し、モジュールレベルのモックに依存しないようテストを調整して、テストの分離性を向上させます。

Enhancements:
- データベースクライアントの作成処理を新しい `create-db` モジュールにリファクタリングし、`db.ts` は初期化済みの単一の `db` インスタンスのみをエクスポートするように制限することで、ランタイムの境界をより明確にします。

Tests:
- Bun のモジュールモックを削除し、ローカルのモックバックエンド実装とファクトリロジックに依拠することで、ストレージファクトリのユニットテストを簡素化します。
- データベースのユニットテストおよびプロパティベーステストで、新しい `create-db` モジュールから `createDb` をインポートするように更新し、`db` ランタイムモジュールからのインポートを置き換えます。
- `test:unit` スクリプトで Bun の `--isolate` および `--randomize` フラグを有効にし、ユニットテストを分離されたランダムな順序で実行します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract database client factory into a dedicated module and adjust tests to avoid relying on module-level mocks while improving test isolation.

Enhancements:
- Refactor database client creation into a new create-db module and restrict db.ts to exporting a single initialized db instance for clearer runtime boundaries.

Tests:
- Simplify storage factory unit tests by removing Bun module mocks and relying on local mock backend implementations and factory logic.
- Update database unit and property-based tests to import createDb from the new create-db module instead of the db runtime module.
- Run unit tests in isolated, randomized order by enabling Bun's --isolate and --randomize flags in the test:unit script.

</details>