### PR TITLE
chore: use standalone only local build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,9 @@ const nextConfig: NextConfig = {
     isrFlushToDisk: false,
     useTypeScriptCli: true,
   },
-  output: "standalone",
+  // Vercel builds its own output and fails on standalone. Everywhere else
+  // (the Docker image, the Playwright webServer on CI) needs it.
+  output: process.env.VERCEL ? undefined : "standalone",
   reactCompiler: true,
   typedRoutes: true,
 }


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Vercel 上で実行する際には standalone モードを無効にしつつ、ローカルおよび CI 環境では standalone を維持するように Next.js のビルド出力を調整しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Adjust Next.js build output to disable standalone mode when running on Vercel while keeping standalone for local and CI environments.

</details>