### PR TITLE
feat: remove turbopack build command

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,12 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+
 updates:
   - package-ecosystem: "bun"
     directory: "/"
@@ -11,26 +19,15 @@ updates:
       dependencies:
         patterns:
           - "*"
+
   - package-ecosystem: "devcontainers"
     directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    groups:
-      devcontainers:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "infrastructure"
+
   - package-ecosystem: "docker"
     directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore"
-    groups:
-      docker:
-        patterns:
-          - "*"
+    multi-ecosystem-group: "infrastructure"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,7 +30,7 @@ jobs:
         run: mise update
 
       - name: 🔷 Run Lint
-        run: mise lint
+        run: mise fix
 
       - name: 💾 Commit
         if: success() || failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,16 +54,15 @@ drizzle/                 # Database migration files
 | ---------------------- | -------------------- |
 | Dev server             | `bun dev`            |
 | Build                  | `bun run build`      |
-| Lint (Biome)           | `bun lint`           |
-| Format (Biome)         | `bun format`         |
-| Lint + Format fix      | `bun lint:fix`       |
+| Check (Biome)          | `bun check`          |
+| Auto-fix (Biome)       | `bun fix`            |
 | Unit tests             | `bun test:unit`      |
 | E2E tests              | `bun test:e2e`       |
 | DB migration generate  | `bun run generate`   |
 | DB migration apply     | `bun run migrate`    |
 | Drizzle Studio         | `bun run studio`     |
-| Markdown lint          | `mise lint:md`       |
-| Full lint (Biome + MD) | `mise lint`          |
+| Markdown fix           | `mise fix:md`        |
+| Full fix (Biome + MD)  | `mise fix`           |
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun test:e2e
 ### 7. Format and Lint the files
 
 ```bash
-bun lint:fix
+bun fix
 ```
 
 ### 8. Build the app

--- a/mise.toml
+++ b/mise.toml
@@ -15,10 +15,10 @@ bun run scripts/dev-up.ts
 bun run migrate
 """
 
-[tasks.lint]
-run = ["bun lint:fix --unsafe", "mise lint:md"]
+[tasks.fix]
+run = ["bun fix --unsafe", "mise fix:md"]
 
-[tasks."lint:md"]
+[tasks."fix:md"]
 description = "Check markdown files for linting issues"
 run = "rumdl check --fix ."
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   experimental: {
     inlineCss: true,
     isrFlushToDisk: false,
-    useTypeScriptCli: true,
   },
   // Vercel builds its own output and fails on standalone. Everywhere else
   // (the Docker image, the Playwright webServer on CI) needs it.

--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
     "url": "https://github.com/OpenUp-LabTakizawa/dcrs/issues"
   },
   "scripts": {
-    "dev": "next dev --turbopack",
-    "dev-win": "WATCHPACK_POLLING=true next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "dev-win": "WATCHPACK_POLLING=true next dev",
+    "build": "next build",
     "start": "next start",
-    "lint": "biome lint --write",
-    "format": "biome format --write",
-    "lint:fix": "biome check --write",
+    "check": "biome check",
+    "fix": "biome check --write",
     "test:unit": "bun test test/unit --preload ./happydom.ts --isolate --randomize",
     "test:e2e": "playwright test",
     "test:report": "playwright show-report",


### PR DESCRIPTION
## Summary by Sourcery

Turbopack の使用を廃止し、Biome と Markdown の lint/fix コマンドを統合するとともに、ドキュメントと自動化ワークフローを新しいコマンドに合わせて整備することで、ビルドおよび開発ツーリングを簡素化します。

Enhancements:
- Biome のスクリプトを標準化し、個別の lint/format スクリプトではなく、汎用的な check および fix コマンドを使用するように変更。
- プロジェクト全体の自動修正フローを統一し、Biome と Markdown の自動修正を両方実行する単一の mise タスクを用意。
- 新しい Biome および Markdown の fix コマンドとその使い方を反映するようにドキュメントを更新。
- 廃止された Next.js の experimental TypeScript CLI 設定を削除。

Build:
- package.json 内の dev および build スクリプトから Turbopack フラグを削除。

CI:
- GitHub の autofix ワークフローを調整し、新しい統一された mise fix コマンドを使用するように変更。

Documentation:
- AGENTS と README の手順を更新し、新しい check/fix コマンドと最新の Markdown ツーリングの説明を参照するように刷新。

Chores:
- Dependabot 設定を見直し、devcontainers と Docker に対して、共有のマルチエコシステム向けインフラ更新グループを使用するように改善。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify build and development tooling by removing Turbopack usage, consolidating Biome and markdown lint/fix commands, and aligning documentation and automation workflows with the new commands.

Enhancements:
- Standardize Biome scripts to use generic check and fix commands instead of separate lint/format scripts.
- Unify project-wide fix workflow via a single mise task that runs both Biome and markdown auto-fixes.
- Update documentation to reflect the new Biome and markdown fix commands and usage.
- Remove deprecated Next.js experimental TypeScript CLI configuration.

Build:
- Remove Turbopack flags from dev and build scripts in package.json.

CI:
- Adjust autofix GitHub workflow to use the new unified mise fix command.

Documentation:
- Refresh AGENTS and README instructions to point to the new check/fix commands and updated markdown tooling description.

Chores:
- Refine Dependabot configuration to use a shared multi-ecosystem infrastructure update group for devcontainers and Docker.

</details>